### PR TITLE
feat: 年历整年操作 + 115校对调试

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,27 @@
 3. 点击"获取下载链接"按钮
 4. 查看游戏列表和对应的下载链接
 
+## 闲时自动任务（Getchu入库 / 磁链入库 / 115已下载校验）
+
+项目新增 CLI：`python tool/cli.py auto idle_run`，用于在“闲时”自动执行：
+- 当年 Getchu 游戏入库（已存在的记录会跳过）
+- 当年 Nyaa 磁链获取入库（已存在 link 的记录会跳过）
+- 115 登录有效时：对“有磁链且未标记已下载”的记录进行 115 已下载校验（不会自动发起 115 云下载）
+
+### 配置项
+在 `tool/config.json` 可选增加：
+- `idle_timezone`：闲时判断时区（默认 `Asia/Tokyo`）
+- `idle_start_hour`：闲时开始小时（默认 `0`）
+- `idle_end_hour`：闲时结束小时（默认 `9`，按 `[start, end)` 判断）
+
+### cron 示例
+由你在服务器上自行配置 cron。命令本身会判断是否在闲时，不在闲时会自动退出（输出 JSON 便于日志排查）。
+
+例如每小时执行一次（00:00-09:00 期间会真正跑，其余时间会跳过）：
+```cron
+0 * * * * cd /path/to/repo && /path/to/repo/.venv/bin/python tool/cli.py auto idle_run >> logs/idle_run.log 2>&1
+```
+
 ## 磁链校验测试页
 
 - 入口：数据展示页每条含磁链记录的“校验”按钮，会打开 `tool/magnet_check.php`

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@
 ### cron 示例
 由你在服务器上自行配置 cron。命令本身会判断是否在闲时，不在闲时会自动退出（输出 JSON 便于日志排查）。
 
-例如每小时执行一次（00:00-09:00 期间会真正跑，其余时间会跳过）：
+另外，`idle_run` 会记录“本周是否已运行”，同一自然周内重复触发会自动跳过（除非加 `--force`）。
+
+例如每周执行一次（周日 00:00 执行）：
 ```cron
-0 * * * * cd /path/to/repo && /path/to/repo/.venv/bin/python tool/cli.py auto idle_run >> logs/idle_run.log 2>&1
+0 0 * * 0 cd /path/to/repo && /path/to/repo/.venv/bin/python tool/cli.py auto idle_run >> logs/idle_run.log 2>&1
 ```
 
 ## 磁链校验测试页

--- a/calendar.php
+++ b/calendar.php
@@ -58,6 +58,32 @@
             </div>
         </div>
 
+        <div class="modal fade" id="yearCheckModal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-lg modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">115 整年校对</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="d-flex align-items-center justify-content-between mb-2">
+                            <div class="fw-semibold" id="yearCheckTitle"></div>
+                            <button type="button" class="btn btn-outline-danger btn-sm" id="yearCheckStopBtn">停止</button>
+                        </div>
+                        <div class="d-flex justify-content-between small text-muted mb-1">
+                            <span id="yearCheckText">准备中...</span>
+                            <span id="yearCheckCount"></span>
+                        </div>
+                        <div class="progress mb-2" style="height: 18px;">
+                            <div class="progress-bar progress-bar-striped progress-bar-animated bg-info" id="yearCheckBar"
+                                role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+                        </div>
+                        <div id="yearCheckErrors" class="small text-muted" style="white-space:pre-wrap;word-break:break-all;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="card">
             <div class="card-header fw-semibold">月度概览</div>
             <div class="table-responsive">
@@ -117,7 +143,7 @@ function renderCalendar(res) {
     body.innerHTML = res.years.map(y => {
         const first = y.months.slice(0, 6).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
         const second = y.months.slice(6, 12).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
-        return `<tr><th class="text-center" rowspan="2">${y.year}</th>${first}</tr><tr>${second}</tr>`;
+        return `<tr><th class="text-center" rowspan="2"><div class="fw-semibold">${y.year}</div><button type="button" class="btn btn-outline-info btn-sm mt-2 year-check-btn" data-year="${y.year}">115整年校对</button></th>${first}</tr><tr>${second}</tr>`;
     }).join('');
 }
 
@@ -150,10 +176,107 @@ function initYears() {
         });
 }
 
+let yearCheckIntervalId = null;
+let yearCheckYear = null;
+
+function resetYearCheckUI() {
+    document.getElementById('yearCheckText').textContent = '准备中...';
+    document.getElementById('yearCheckCount').textContent = '';
+    document.getElementById('yearCheckErrors').textContent = '';
+    const bar = document.getElementById('yearCheckBar');
+    bar.style.width = '0%';
+    bar.setAttribute('aria-valuenow', '0');
+}
+
+function openYearCheckModal(year) {
+    yearCheckYear = year;
+    document.getElementById('yearCheckTitle').textContent = `年份：${year}`;
+    resetYearCheckUI();
+    new bootstrap.Modal(document.getElementById('yearCheckModal')).show();
+}
+
+function pollYearCheckStatus() {
+    fetch(`${basePath}/tool/api.php?action=115_check_all_status`)
+        .then(r => r.json())
+        .then(status => {
+            const bar = document.getElementById('yearCheckBar');
+            if (status.running) {
+                const progress = status.total > 0 ? Math.round(status.checked / status.total * 100) : 0;
+                document.getElementById('yearCheckText').textContent = `校对中... (已检查 ${status.checked}/${status.total})`;
+                document.getElementById('yearCheckCount').textContent = `发现 ${status.found_downloaded} 条已下载`;
+                bar.style.width = `${progress}%`;
+                bar.setAttribute('aria-valuenow', `${progress}`);
+                if (status.errors && status.errors.length > 0) {
+                    document.getElementById('yearCheckErrors').textContent = '错误（前10条）:\n' + status.errors.join('\n');
+                }
+                return;
+            }
+
+            if (yearCheckIntervalId) {
+                clearInterval(yearCheckIntervalId);
+                yearCheckIntervalId = null;
+            }
+
+            bootstrap.Modal.getInstance(document.getElementById('yearCheckModal'))?.hide();
+
+            let msg = `校对完成\n\n总记录: ${status.total}\n已检查: ${status.checked}\n发现已下载: ${status.found_downloaded}`;
+            if (status.errors && status.errors.length > 0) {
+                msg += '\n\n错误（前10条）:\n' + status.errors.join('\n');
+            }
+            alert(msg);
+
+            const sel = document.getElementById('calendar-year');
+            loadCalendar(sel.value);
+        })
+        .catch(() => {});
+}
+
+function startYearCheck(year) {
+    openYearCheckModal(year);
+    if (yearCheckIntervalId) {
+        clearInterval(yearCheckIntervalId);
+        yearCheckIntervalId = null;
+    }
+
+    fetch(`${basePath}/tool/api.php?action=115_check_all_start`, {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({ year: parseInt(year, 10) }),
+    }).then(r => r.json()).then(res => {
+        if (res.status === 'error') {
+            alert('启动失败: ' + (res.message || '未知错误'));
+            bootstrap.Modal.getInstance(document.getElementById('yearCheckModal'))?.hide();
+            return;
+        }
+        yearCheckIntervalId = setInterval(pollYearCheckStatus, 3000);
+    }).catch(err => {
+        alert('启动失败: ' + err.message);
+        bootstrap.Modal.getInstance(document.getElementById('yearCheckModal'))?.hide();
+    });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     initYears();
     document.getElementById('calendar-year').addEventListener('change', (e) => {
         loadCalendar(e.target.value);
+    });
+
+    document.getElementById('calendar-body').addEventListener('click', (e) => {
+        const btn = e.target.closest('.year-check-btn');
+        if (!btn) return;
+        const year = btn.dataset.year;
+        if (!year) return;
+        if (!confirm(`将对 ${year} 年所有有磁链且未标记已下载的记录进行115校对，是否继续？`)) return;
+        startYearCheck(year);
+    });
+
+    document.getElementById('yearCheckStopBtn').addEventListener('click', () => {
+        fetch(`${basePath}/tool/api.php?action=115_check_all_stop`, { method: 'POST' }).catch(() => {});
+        if (yearCheckIntervalId) {
+            clearInterval(yearCheckIntervalId);
+            yearCheckIntervalId = null;
+        }
+        bootstrap.Modal.getInstance(document.getElementById('yearCheckModal'))?.hide();
     });
 });
     </script>

--- a/calendar.php
+++ b/calendar.php
@@ -22,6 +22,10 @@
             opacity: 0.9;
             white-space: nowrap;
         }
+        .month-cell a:hover {
+            background-color: rgba(13, 110, 253, 0.06);
+            border-radius: 4px;
+        }
     </style>
 </head>
 <body style="padding-top: 56px;">
@@ -75,7 +79,7 @@ const basePath = <?= json_encode($base, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_
 
 function buildHeader() {
     const headRow = document.getElementById('calendar-head-row');
-    headRow.innerHTML = '<th style="width:96px;">年份</th>' + Array.from({length: 6}).map((_, i) => `<th class="text-center">${i + 1}</th>`).join('');
+    headRow.innerHTML = '<th class="text-center" style="width:96px;">年份</th>' + Array.from({length: 6}).map((_, i) => `<th class="text-center">${i + 1}</th>`).join('');
 }
 
 function cellClass(m) {
@@ -85,17 +89,20 @@ function cellClass(m) {
     return 'table-warning';
 }
 
-function cellHtml(m) {
+function cellHtml(year, m) {
     if (!m.has_data) return '<div class="month-cell"><div class="small">-</div></div>';
     const badges = [];
     badges.push('<span class="badge bg-secondary">有数据</span>');
     if (m.all_magnet_submitted) badges.push('<span class="badge bg-light text-dark">全提交</span>');
     if (m.all_magnet_downloaded) badges.push('<span class="badge bg-light text-dark">全下载</span>');
+    const href = `${basePath}/tool/data.php?year=${year}&month=${String(m.month).padStart(2, '0')}`;
     return `
         <div class="month-cell">
-            <div class="fw-semibold text-center">${String(m.month).padStart(2, '0')}</div>
-            <div class="badges">${badges.join('')}</div>
-            <div class="counts">磁链 S:${m.magnet_submitted}/${m.magnet_total} D:${m.magnet_downloaded}/${m.magnet_total}</div>
+            <a href="${href}" class="text-decoration-none d-block text-reset">
+                <div class="fw-semibold text-center">${String(m.month).padStart(2, '0')}</div>
+                <div class="badges">${badges.join('')}</div>
+                <div class="counts">磁链 S:${m.magnet_submitted}/${m.magnet_total} D:${m.magnet_downloaded}/${m.magnet_total}</div>
+            </a>
         </div>
     `;
 }
@@ -108,8 +115,8 @@ function renderCalendar(res) {
     }
 
     body.innerHTML = res.years.map(y => {
-        const first = y.months.slice(0, 6).map(m => `<td class="${cellClass(m)}">${cellHtml(m)}</td>`).join('');
-        const second = y.months.slice(6, 12).map(m => `<td class="${cellClass(m)}">${cellHtml(m)}</td>`).join('');
+        const first = y.months.slice(0, 6).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
+        const second = y.months.slice(6, 12).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
         return `<tr><th class="text-center" rowspan="2">${y.year}</th>${first}</tr><tr>${second}</tr>`;
     }).join('');
 }

--- a/calendar.php
+++ b/calendar.php
@@ -8,7 +8,7 @@
         .calendar-table td, .calendar-table th {
             vertical-align: top;
             padding: 8px;
-            min-width: 86px;
+            min-width: 72px;
         }
         .month-cell .badges {
             margin-top: 4px;
@@ -75,7 +75,7 @@ const basePath = <?= json_encode($base, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_
 
 function buildHeader() {
     const headRow = document.getElementById('calendar-head-row');
-    headRow.innerHTML = '<th style="width:96px;">年份</th>' + Array.from({length: 12}).map((_, i) => `<th class="text-center">${i + 1}月</th>`).join('');
+    headRow.innerHTML = '<th style="width:96px;">年份</th>' + Array.from({length: 6}).map((_, i) => `<th class="text-center">${i + 1}</th>`).join('');
 }
 
 function cellClass(m) {
@@ -103,13 +103,14 @@ function cellHtml(m) {
 function renderCalendar(res) {
     const body = document.getElementById('calendar-body');
     if (!res || !Array.isArray(res.years)) {
-        body.innerHTML = '<tr><td colspan="13" class="text-center text-muted py-4">加载失败</td></tr>';
+        body.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-4">加载失败</td></tr>';
         return;
     }
 
     body.innerHTML = res.years.map(y => {
-        const tds = y.months.map(m => `<td class="${cellClass(m)}">${cellHtml(m)}</td>`).join('');
-        return `<tr><th class="text-center">${y.year}</th>${tds}</tr>`;
+        const first = y.months.slice(0, 6).map(m => `<td class="${cellClass(m)}">${cellHtml(m)}</td>`).join('');
+        const second = y.months.slice(6, 12).map(m => `<td class="${cellClass(m)}">${cellHtml(m)}</td>`).join('');
+        return `<tr><th class="text-center" rowspan="2">${y.year}</th>${first}</tr><tr>${second}</tr>`;
     }).join('');
 }
 
@@ -151,4 +152,3 @@ document.addEventListener('DOMContentLoaded', () => {
     </script>
 </body>
 </html>
-

--- a/calendar.php
+++ b/calendar.php
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>年历</title>
+    <link href="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        .calendar-table td, .calendar-table th {
+            vertical-align: top;
+            padding: 8px;
+            min-width: 86px;
+        }
+        .month-cell .badges {
+            margin-top: 4px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+        }
+        .month-cell .counts {
+            margin-top: 4px;
+            font-size: 12px;
+            opacity: 0.9;
+            white-space: nowrap;
+        }
+    </style>
+</head>
+<body style="padding-top: 56px;">
+<?php $base = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/'); if ($base === '/') $base = ''; ?>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+        <div class="container">
+            <a class="navbar-brand" href="#">年历</a>
+            <div class="navbar-nav">
+                <a class="nav-link" href="<?= $base ?>/index.php">首页</a>
+                <a class="nav-link" href="<?= $base ?>/tool/data.php">数据展示</a>
+                <a class="nav-link active" href="<?= $base ?>/calendar.php">年历</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container mt-4">
+        <div class="card mb-3">
+            <div class="card-body">
+                <div class="row g-2 align-items-end">
+                    <div class="col-12 col-lg-6">
+                        <label class="form-label mb-1">选择年份（展示该年及前两年）</label>
+                        <select id="calendar-year" class="form-select"></select>
+                    </div>
+                    <div class="col-12 col-lg-6">
+                        <div class="small text-muted">
+                            颜色说明：绿色=全部已下载，蓝色=全部已提交115，黄色=已采集但未全完成，灰色=无数据
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header fw-semibold">月度概览</div>
+            <div class="table-responsive">
+                <table class="table table-bordered calendar-table mb-0">
+                    <thead class="table-dark">
+                        <tr id="calendar-head-row">
+                            <th style="width:96px;">年份</th>
+                        </tr>
+                    </thead>
+                    <tbody id="calendar-body"></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/js/bootstrap.bundle.min.js"></script>
+    <script>
+const basePath = <?= json_encode($base, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+
+function buildHeader() {
+    const headRow = document.getElementById('calendar-head-row');
+    headRow.innerHTML = '<th style="width:96px;">年份</th>' + Array.from({length: 12}).map((_, i) => `<th class="text-center">${i + 1}月</th>`).join('');
+}
+
+function cellClass(m) {
+    if (!m.has_data) return 'table-light text-muted';
+    if (m.all_magnet_downloaded) return 'table-success';
+    if (m.all_magnet_submitted) return 'table-primary';
+    return 'table-warning';
+}
+
+function cellHtml(m) {
+    if (!m.has_data) return '<div class="month-cell"><div class="small">-</div></div>';
+    const badges = [];
+    badges.push('<span class="badge bg-secondary">有数据</span>');
+    if (m.all_magnet_submitted) badges.push('<span class="badge bg-light text-dark">全提交</span>');
+    if (m.all_magnet_downloaded) badges.push('<span class="badge bg-light text-dark">全下载</span>');
+    return `
+        <div class="month-cell">
+            <div class="fw-semibold text-center">${String(m.month).padStart(2, '0')}</div>
+            <div class="badges">${badges.join('')}</div>
+            <div class="counts">磁链 S:${m.magnet_submitted}/${m.magnet_total} D:${m.magnet_downloaded}/${m.magnet_total}</div>
+        </div>
+    `;
+}
+
+function renderCalendar(res) {
+    const body = document.getElementById('calendar-body');
+    if (!res || !Array.isArray(res.years)) {
+        body.innerHTML = '<tr><td colspan="13" class="text-center text-muted py-4">加载失败</td></tr>';
+        return;
+    }
+
+    body.innerHTML = res.years.map(y => {
+        const tds = y.months.map(m => `<td class="${cellClass(m)}">${cellHtml(m)}</td>`).join('');
+        return `<tr><th class="text-center">${y.year}</th>${tds}</tr>`;
+    }).join('');
+}
+
+function loadCalendar(year) {
+    const url = `${basePath}/tool/api.php?action=calendar&year=${encodeURIComponent(year)}`;
+    fetch(url).then(r => r.json()).then(renderCalendar).catch(() => {
+        renderCalendar(null);
+    });
+}
+
+function initYears() {
+    buildHeader();
+    fetch(`${basePath}/tool/api.php?action=years`)
+        .then(r => r.json())
+        .then(res => {
+            const sel = document.getElementById('calendar-year');
+            const nowYear = new Date().getFullYear();
+            const years = Array.isArray(res.years) ? res.years.slice() : [];
+            if (!years.includes(nowYear)) years.push(nowYear);
+            years.sort((a,b) => b-a);
+            sel.innerHTML = years.map(y => `<option value="${y}">${y}</option>`).join('');
+            sel.value = years[0] || nowYear;
+            loadCalendar(sel.value);
+        })
+        .catch(() => {
+            const sel = document.getElementById('calendar-year');
+            const nowYear = new Date().getFullYear();
+            sel.innerHTML = `<option value="${nowYear}">${nowYear}</option>`;
+            loadCalendar(nowYear);
+        });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initYears();
+    document.getElementById('calendar-year').addEventListener('change', (e) => {
+        loadCalendar(e.target.value);
+    });
+});
+    </script>
+</body>
+</html>
+

--- a/calendar.php
+++ b/calendar.php
@@ -194,7 +194,7 @@ function renderCalendar(res) {
     body.innerHTML = res.years.map(y => {
         const first = y.months.slice(0, 6).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
         const second = y.months.slice(6, 12).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
-        return `<tr><th class="text-center align-middle" rowspan="2"><div class="d-flex align-items-center justify-content-center gap-1"><span class="fw-semibold">${y.year}</span><div class="btn-group btn-group-sm" role="group"><button type="button" class="btn btn-outline-info year-check-btn" data-year="${y.year}" title="115校对">校</button><button type="button" class="btn btn-outline-success year-download-btn" data-year="${y.year}" title="获取链接">链</button><button type="button" class="btn btn-outline-primary year-push-btn" data-year="${y.year}" title="推送115">推</button></div></div></th>${first}</tr><tr>${second}</tr>`;
+        return `<tr><th class="text-center align-middle" rowspan="2"><div class="fw-semibold">${y.year}</div><div class="d-grid gap-1 mt-2"><button type="button" class="btn btn-outline-info btn-sm year-check-btn" data-year="${y.year}">校对</button><button type="button" class="btn btn-outline-success btn-sm year-download-btn" data-year="${y.year}">下载</button><button type="button" class="btn btn-outline-primary btn-sm year-push-btn" data-year="${y.year}">推送</button></div></th>${first}</tr><tr>${second}</tr>`;
     }).join('');
 }
 

--- a/calendar.php
+++ b/calendar.php
@@ -194,7 +194,7 @@ function renderCalendar(res) {
     body.innerHTML = res.years.map(y => {
         const first = y.months.slice(0, 6).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
         const second = y.months.slice(6, 12).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
-        return `<tr><th class="text-center align-middle" rowspan="2"><div class="fw-semibold">${y.year}</div><div class="d-grid gap-1 mt-2"><button type="button" class="btn btn-outline-info btn-sm year-check-btn" data-year="${y.year}">校对</button><button type="button" class="btn btn-outline-success btn-sm year-download-btn" data-year="${y.year}">下载</button><button type="button" class="btn btn-outline-primary btn-sm year-push-btn" data-year="${y.year}">推送</button></div></th>${first}</tr><tr>${second}</tr>`;
+        return `<tr><th class="text-center align-middle" rowspan="2"><div class="fw-semibold">${y.year}</div><div class="d-grid gap-1 mt-2"><button type="button" class="btn btn-outline-success btn-sm year-download-btn" data-year="${y.year}">下载</button><button type="button" class="btn btn-outline-info btn-sm year-check-btn" data-year="${y.year}">校对</button><button type="button" class="btn btn-outline-primary btn-sm year-push-btn" data-year="${y.year}">推送</button></div></th>${first}</tr><tr>${second}</tr>`;
     }).join('');
 }
 

--- a/calendar.php
+++ b/calendar.php
@@ -84,6 +84,57 @@
             </div>
         </div>
 
+        <div class="modal fade" id="yearDownloadModal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-lg modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">整年获取下载链接</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="d-flex align-items-center justify-content-between mb-2">
+                            <div class="fw-semibold" id="yearDownloadTitle"></div>
+                            <button type="button" class="btn btn-outline-danger btn-sm" id="yearDownloadStopBtn">停止</button>
+                        </div>
+                        <div class="d-flex justify-content-between small text-muted mb-1">
+                            <span id="yearDownloadText">准备中...</span>
+                            <span id="yearDownloadCount"></span>
+                        </div>
+                        <div class="progress mb-2" style="height: 18px;">
+                            <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" id="yearDownloadBar"
+                                role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="modal fade" id="yearPushModal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-lg modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">整年推送115</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="d-flex align-items-center justify-content-between mb-2">
+                            <div class="fw-semibold" id="yearPushTitle"></div>
+                            <button type="button" class="btn btn-outline-danger btn-sm" id="yearPushStopBtn">停止</button>
+                        </div>
+                        <div class="d-flex justify-content-between small text-muted mb-1">
+                            <span id="yearPushText">准备中...</span>
+                            <span id="yearPushCount"></span>
+                        </div>
+                        <div class="progress mb-2" style="height: 18px;">
+                            <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" id="yearPushBar"
+                                role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+                        </div>
+                        <div id="yearPushErrors" class="small text-muted" style="white-space:pre-wrap;word-break:break-all;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="card">
             <div class="card-header fw-semibold">月度概览</div>
             <div class="table-responsive">
@@ -143,7 +194,7 @@ function renderCalendar(res) {
     body.innerHTML = res.years.map(y => {
         const first = y.months.slice(0, 6).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
         const second = y.months.slice(6, 12).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
-        return `<tr><th class="text-center" rowspan="2"><div class="fw-semibold">${y.year}</div><button type="button" class="btn btn-outline-info btn-sm mt-2 year-check-btn" data-year="${y.year}">115整年校对</button></th>${first}</tr><tr>${second}</tr>`;
+        return `<tr><th class="text-center align-middle" rowspan="2"><div class="d-flex align-items-center justify-content-center gap-1"><span class="fw-semibold">${y.year}</span><div class="btn-group btn-group-sm" role="group"><button type="button" class="btn btn-outline-info year-check-btn" data-year="${y.year}" title="115校对">校</button><button type="button" class="btn btn-outline-success year-download-btn" data-year="${y.year}" title="获取链接">链</button><button type="button" class="btn btn-outline-primary year-push-btn" data-year="${y.year}" title="推送115">推</button></div></div></th>${first}</tr><tr>${second}</tr>`;
     }).join('');
 }
 
@@ -178,6 +229,8 @@ function initYears() {
 
 let yearCheckIntervalId = null;
 let yearCheckYear = null;
+let yearDownloadIntervalId = null;
+let yearPushStopRequested = false;
 
 function resetYearCheckUI() {
     document.getElementById('yearCheckText').textContent = '准备中...';
@@ -255,6 +308,198 @@ function startYearCheck(year) {
     });
 }
 
+function resetYearDownloadUI() {
+    document.getElementById('yearDownloadText').textContent = '准备中...';
+    document.getElementById('yearDownloadCount').textContent = '';
+    const bar = document.getElementById('yearDownloadBar');
+    bar.style.width = '0%';
+    bar.setAttribute('aria-valuenow', '0');
+}
+
+function openYearDownloadModal(year) {
+    document.getElementById('yearDownloadTitle').textContent = `年份：${year}`;
+    resetYearDownloadUI();
+    new bootstrap.Modal(document.getElementById('yearDownloadModal')).show();
+}
+
+function pollYearDownloadStatus() {
+    fetch(`${basePath}/tool/api.php?action=download_status`)
+        .then(r => r.json())
+        .then(status => {
+            const bar = document.getElementById('yearDownloadBar');
+            if (status.running) {
+                const progress = status.total_months > 0 ? Math.round(status.finished_months / status.total_months * 100) : 0;
+                document.getElementById('yearDownloadText').textContent = `获取中... (${status.finished_months}/${status.total_months})`;
+                bar.style.width = `${progress}%`;
+                bar.setAttribute('aria-valuenow', `${progress}`);
+                return;
+            }
+
+            if (yearDownloadIntervalId) {
+                clearInterval(yearDownloadIntervalId);
+                yearDownloadIntervalId = null;
+            }
+
+            bootstrap.Modal.getInstance(document.getElementById('yearDownloadModal'))?.hide();
+            alert(status && status.message === 'success' ? '完成' : ('失败: ' + (status && status.message ? status.message : 'unknown')));
+
+            const sel = document.getElementById('calendar-year');
+            loadCalendar(sel.value);
+        })
+        .catch(() => {});
+}
+
+function startYearDownload(year) {
+    openYearDownloadModal(year);
+    if (yearDownloadIntervalId) {
+        clearInterval(yearDownloadIntervalId);
+        yearDownloadIntervalId = null;
+    }
+    fetch(`${basePath}/tool/api.php?action=start_download`, {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({ year: parseInt(year, 10), month: 0 }),
+    }).then(r => r.json()).then(res => {
+        if (res.status === 'error') {
+            alert('启动失败: ' + (res.message || '未知错误'));
+            bootstrap.Modal.getInstance(document.getElementById('yearDownloadModal'))?.hide();
+            return;
+        }
+        yearDownloadIntervalId = setInterval(pollYearDownloadStatus, 3000);
+    }).catch(err => {
+        alert('启动失败: ' + err.message);
+        bootstrap.Modal.getInstance(document.getElementById('yearDownloadModal'))?.hide();
+    });
+}
+
+function resetYearPushUI() {
+    document.getElementById('yearPushText').textContent = '准备中...';
+    document.getElementById('yearPushCount').textContent = '';
+    document.getElementById('yearPushErrors').textContent = '';
+    const bar = document.getElementById('yearPushBar');
+    bar.style.width = '0%';
+    bar.setAttribute('aria-valuenow', '0');
+}
+
+function openYearPushModal(year) {
+    document.getElementById('yearPushTitle').textContent = `年份：${year}`;
+    resetYearPushUI();
+    new bootstrap.Modal(document.getElementById('yearPushModal')).show();
+}
+
+function updateYearPushProgress(done, total, ok, fail) {
+    const bar = document.getElementById('yearPushBar');
+    const progress = total > 0 ? Math.round(done / total * 100) : 0;
+    bar.style.width = `${progress}%`;
+    bar.setAttribute('aria-valuenow', `${progress}`);
+    document.getElementById('yearPushCount').textContent = `${done}/${total} 成功${ok} 失败${fail}`;
+}
+
+async function startYearPush(year) {
+    openYearPushModal(year);
+    yearPushStopRequested = false;
+
+    let login = null;
+    try {
+        login = await fetch(`${basePath}/tool/api.php?action=115_login_status`).then(r => r.json());
+    } catch (e) {
+        login = null;
+    }
+    if (!login || !login.logged_in) {
+        bootstrap.Modal.getInstance(document.getElementById('yearPushModal'))?.hide();
+        alert('未登录115');
+        return;
+    }
+
+    const perPage = 50;
+    let page = 1;
+    let total = 0;
+    let done = 0;
+    let ok = 0;
+    let fail = 0;
+    const errors = [];
+    document.getElementById('yearPushText').textContent = '统计中...';
+
+    while (true) {
+        if (yearPushStopRequested) break;
+        let res = null;
+        try {
+            res = await fetch(`${basePath}/tool/api.php?action=games&page=${page}&year=${encodeURIComponent(year)}`).then(r => r.json());
+        } catch (e) {
+            errors.push(`page ${page}: ${e.message || e}`);
+            break;
+        }
+        if (!res || res.status === 'error') {
+            errors.push(`page ${page}: ${(res && res.message) ? res.message : 'error'}`);
+            break;
+        }
+        if (page === 1) {
+            total = parseInt(res.total || 0, 10) || 0;
+        }
+
+        const list = Array.isArray(res.data) ? res.data : [];
+        if (list.length === 0) break;
+
+        for (const g of list) {
+            if (yearPushStopRequested) break;
+            const magnet = g.download_url || '';
+            const submitted = parseInt(g.submitted_115 || 0, 10) === 1;
+            if (!magnet || submitted) {
+                done += 1;
+                updateYearPushProgress(done, total, ok, fail);
+                continue;
+            }
+            document.getElementById('yearPushText').textContent = g.name || '提交中...';
+            try {
+                const r = await fetch(`${basePath}/tool/api.php?action=115_submit`, {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({ magnet, dir: `/GAL/GAL-${year}` }),
+                }).then(rr => rr.json());
+                if (r && r.success) {
+                    ok += 1;
+                    try {
+                        await fetch(`${basePath}/tool/api.php?action=update_game`, {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({
+                                date: `${year}-${String(g.month).padStart(2, '0')}`,
+                                old_name: g.name,
+                                new_submitted_115: 1,
+                                new_submitted_pick_code: r.pick_code || '',
+                            }),
+                        });
+                    } catch (e) {}
+                } else {
+                    fail += 1;
+                    errors.push(`${g.name}: ${(r && r.message) ? r.message : 'failed'}`);
+                }
+            } catch (e) {
+                fail += 1;
+                errors.push(`${g.name}: ${e.message || e}`);
+            }
+            done += 1;
+            updateYearPushProgress(done, total, ok, fail);
+            if (errors.length > 0) {
+                document.getElementById('yearPushErrors').textContent = errors.slice(0, 10).join('\n');
+            }
+        }
+
+        if (yearPushStopRequested) break;
+        if (list.length < perPage) break;
+        page += 1;
+    }
+
+    bootstrap.Modal.getInstance(document.getElementById('yearPushModal'))?.hide();
+    let msg = yearPushStopRequested ? '已停止' : '完成';
+    msg += `\n成功 ${ok} 失败 ${fail}`;
+    if (errors.length > 0) msg += `\n\n错误（前10条）:\n` + errors.slice(0, 10).join('\n');
+    alert(msg);
+
+    const sel = document.getElementById('calendar-year');
+    loadCalendar(sel.value);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     initYears();
     document.getElementById('calendar-year').addEventListener('change', (e) => {
@@ -262,12 +507,29 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('calendar-body').addEventListener('click', (e) => {
-        const btn = e.target.closest('.year-check-btn');
-        if (!btn) return;
-        const year = btn.dataset.year;
-        if (!year) return;
-        if (!confirm(`将对 ${year} 年所有有磁链且未标记已下载的记录进行115校对，是否继续？`)) return;
-        startYearCheck(year);
+        const btn1 = e.target.closest('.year-check-btn');
+        if (btn1) {
+            const year = btn1.dataset.year;
+            if (!year) return;
+            if (!confirm(`${year}：115校对？`)) return;
+            startYearCheck(year);
+            return;
+        }
+        const btn2 = e.target.closest('.year-download-btn');
+        if (btn2) {
+            const year = btn2.dataset.year;
+            if (!year) return;
+            if (!confirm(`${year}：获取链接？`)) return;
+            startYearDownload(year);
+            return;
+        }
+        const btn3 = e.target.closest('.year-push-btn');
+        if (btn3) {
+            const year = btn3.dataset.year;
+            if (!year) return;
+            if (!confirm(`${year}：推送115？`)) return;
+            startYearPush(year);
+        }
     });
 
     document.getElementById('yearCheckStopBtn').addEventListener('click', () => {
@@ -277,6 +539,20 @@ document.addEventListener('DOMContentLoaded', () => {
             yearCheckIntervalId = null;
         }
         bootstrap.Modal.getInstance(document.getElementById('yearCheckModal'))?.hide();
+    });
+
+    document.getElementById('yearDownloadStopBtn').addEventListener('click', () => {
+        fetch(`${basePath}/tool/api.php?action=stop_download`, { method: 'POST' }).catch(() => {});
+        if (yearDownloadIntervalId) {
+            clearInterval(yearDownloadIntervalId);
+            yearDownloadIntervalId = null;
+        }
+        bootstrap.Modal.getInstance(document.getElementById('yearDownloadModal'))?.hide();
+    });
+
+    document.getElementById('yearPushStopBtn').addEventListener('click', () => {
+        yearPushStopRequested = true;
+        bootstrap.Modal.getInstance(document.getElementById('yearPushModal'))?.hide();
     });
 });
     </script>

--- a/calendar.php
+++ b/calendar.php
@@ -194,7 +194,7 @@ function renderCalendar(res) {
     body.innerHTML = res.years.map(y => {
         const first = y.months.slice(0, 6).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
         const second = y.months.slice(6, 12).map(m => `<td class="${cellClass(m)}">${cellHtml(y.year, m)}</td>`).join('');
-        return `<tr><th class="text-center align-middle" rowspan="2"><div class="fw-semibold">${y.year}</div><div class="d-grid gap-1 mt-2"><button type="button" class="btn btn-outline-success btn-sm year-download-btn" data-year="${y.year}">下载</button><button type="button" class="btn btn-outline-info btn-sm year-check-btn" data-year="${y.year}">校对</button><button type="button" class="btn btn-outline-primary btn-sm year-push-btn" data-year="${y.year}">推送</button></div></th>${first}</tr><tr>${second}</tr>`;
+        return `<tr><th class="text-center align-middle" rowspan="2"><div class="fw-semibold">${y.year}</div><div class="d-grid gap-1 mt-2"><button type="button" class="btn btn-outline-success btn-sm year-download-btn" data-year="${y.year}">链接</button><button type="button" class="btn btn-outline-info btn-sm year-check-btn" data-year="${y.year}">校对</button><button type="button" class="btn btn-outline-primary btn-sm year-push-btn" data-year="${y.year}">下载</button></div></th>${first}</tr><tr>${second}</tr>`;
     }).join('');
 }
 

--- a/index.php
+++ b/index.php
@@ -14,6 +14,7 @@
             <div class="navbar-nav">
                 <a class="nav-link active" href="<?= $base ?>/index.php">首页</a>
                 <a class="nav-link" href="<?= $base ?>/tool/data.php">数据展示</a>
+                <a class="nav-link" href="<?= $base ?>/calendar.php">年历</a>
             </div>
         </div>
     </nav>

--- a/tool/api.php
+++ b/tool/api.php
@@ -178,7 +178,10 @@ if ($action === '115_check') {
     $body = read_json_body();
     $magnet = $body['magnet'] ?? '';
     $dir = $body['dir'] ?? '';
-    [$code, $data] = run_cli(['115', 'check', '--magnet', $magnet, '--dir', $dir]);
+    $debug = $body['debug'] ?? null;
+    $args = ['115', 'check', '--magnet', $magnet, '--dir', $dir];
+    if ($debug) { $args[] = '--debug'; }
+    [$code, $data] = run_cli($args);
     json_response($data);
 }
 

--- a/tool/api.php
+++ b/tool/api.php
@@ -93,6 +93,14 @@ if ($action === 'games') {
     json_response($data);
 }
 
+if ($action === 'calendar') {
+    $year = as_int($_GET['year'] ?? null, null);
+    $args = ['calendar'];
+    if ($year !== null) { $args[] = '--year'; $args[] = strval($year); }
+    [$code, $data] = run_cli($args);
+    json_response($data);
+}
+
 if ($action === 'get_status') {
     [$code, $data] = run_cli(['spider', 'status']);
     json_response($data);
@@ -213,6 +221,8 @@ if ($action === 'update_game') {
     $new_link = $body['new_link'] ?? null;
     $new_downloaded = $body['new_downloaded'] ?? null;
     $new_nyaa_name = $body['new_nyaa_name'] ?? null;
+    $new_submitted_115 = $body['new_submitted_115'] ?? null;
+    $new_submitted_pick_code = $body['new_submitted_pick_code'] ?? null;
     if (!$date || !$old_name) {
         json_response(['success' => false, 'message' => '缺少必填字段 date/old_name']);
     }
@@ -223,6 +233,8 @@ if ($action === 'update_game') {
     if ($new_link !== null) { $args[] = '--new-link'; $args[] = $new_link; }
     if ($new_downloaded !== null) { $args[] = '--new-downloaded'; $args[] = strval($new_downloaded); }
     if ($new_nyaa_name !== null) { $args[] = '--new-nyaa-name'; $args[] = $new_nyaa_name; }
+    if ($new_submitted_115 !== null) { $args[] = '--new-submitted-115'; $args[] = strval($new_submitted_115); }
+    if ($new_submitted_pick_code !== null) { $args[] = '--new-submitted-pick-code'; $args[] = strval($new_submitted_pick_code); }
     [$code, $data] = run_cli($args);
     json_response($data);
 }

--- a/tool/check_debug.php
+++ b/tool/check_debug.php
@@ -15,7 +15,24 @@
             right: 16px;
             bottom: 16px;
             z-index: 1050;
-            display: none;
+            width: 44px;
+            height: 44px;
+            border-radius: 999px;
+            padding: 0;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            opacity: 0;
+            visibility: hidden;
+            pointer-events: none;
+            transition: opacity 0.15s ease, visibility 0.15s ease, transform 0.15s ease;
+            transform: translateY(6px);
+        }
+        #back-to-top.show {
+            opacity: 1;
+            visibility: visible;
+            pointer-events: auto;
+            transform: translateY(0);
         }
     </style>
 </head>
@@ -62,7 +79,7 @@
         </div>
     </div>
 
-    <button id="back-to-top" type="button" class="btn btn-dark btn-sm">回到页首</button>
+    <button id="back-to-top" type="button" class="btn btn-dark" aria-label="回到页首">↑</button>
 
     <script src="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/js/bootstrap.bundle.min.js"></script>
     <script>
@@ -101,7 +118,8 @@ document.getElementById('dbg-run').addEventListener('click', () => {
 
 const backBtn = document.getElementById('back-to-top');
 function updateBackBtn() {
-    backBtn.style.display = window.scrollY > 200 ? '' : 'none';
+    const y = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+    backBtn.classList.toggle('show', y > 200);
 }
 window.addEventListener('scroll', updateBackBtn, { passive: true });
 updateBackBtn();

--- a/tool/check_debug.php
+++ b/tool/check_debug.php
@@ -10,6 +10,13 @@
             word-break: break-all;
             margin: 0;
         }
+        #back-to-top {
+            position: fixed;
+            right: 16px;
+            bottom: 16px;
+            z-index: 1050;
+            display: none;
+        }
     </style>
 </head>
 <body style="padding-top: 56px;">
@@ -55,6 +62,8 @@
         </div>
     </div>
 
+    <button id="back-to-top" type="button" class="btn btn-dark btn-sm">回到页首</button>
+
     <script src="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/js/bootstrap.bundle.min.js"></script>
     <script>
 const basePath = <?= json_encode($base, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
@@ -89,7 +98,16 @@ document.getElementById('dbg-run').addEventListener('click', () => {
         setBadge(false, '失败');
     });
 });
+
+const backBtn = document.getElementById('back-to-top');
+function updateBackBtn() {
+    backBtn.style.display = window.scrollY > 200 ? '' : 'none';
+}
+window.addEventListener('scroll', updateBackBtn, { passive: true });
+updateBackBtn();
+backBtn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+});
     </script>
 </body>
 </html>
-

--- a/tool/check_debug.php
+++ b/tool/check_debug.php
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>115 校对调试</title>
+    <link href="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        pre {
+            white-space: pre-wrap;
+            word-break: break-all;
+            margin: 0;
+        }
+    </style>
+</head>
+<body style="padding-top: 56px;">
+<?php $base = rtrim(dirname(dirname($_SERVER['SCRIPT_NAME'])), '/'); ?>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+        <div class="container">
+            <a class="navbar-brand" href="#">115 校对调试</a>
+            <div class="navbar-nav">
+                <a class="nav-link" href="<?= $base ?>/index.php">首页</a>
+                <a class="nav-link" href="<?= $base ?>/tool/data.php">数据展示</a>
+                <a class="nav-link active" href="<?= $base ?>/tool/check_debug.php">校对调试</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container mt-4">
+        <div class="card mb-3">
+            <div class="card-header fw-semibold">参数</div>
+            <div class="card-body">
+                <div class="mb-2">
+                    <label class="form-label mb-1">磁力链接</label>
+                    <textarea id="dbg-magnet" class="form-control" rows="3"><?= htmlspecialchars($_GET['magnet'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></textarea>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label mb-1">115 保存路径</label>
+                    <input id="dbg-dir" class="form-control" value="<?= htmlspecialchars($_GET['dir'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>">
+                </div>
+                <div class="d-flex gap-2">
+                    <button id="dbg-run" class="btn btn-primary">执行校对（debug）</button>
+                    <a class="btn btn-outline-secondary" href="<?= $base ?>/tool/data.php">返回数据页</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <span class="fw-semibold">结果</span>
+                <span id="dbg-badge" class="badge bg-secondary">未执行</span>
+            </div>
+            <div class="card-body">
+                <pre id="dbg-out" class="small text-muted">点击“执行校对（debug）”开始</pre>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.1/js/bootstrap.bundle.min.js"></script>
+    <script>
+const basePath = <?= json_encode($base, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+
+function setBadge(ok, text) {
+    const badge = document.getElementById('dbg-badge');
+    badge.textContent = text;
+    badge.className = ok ? 'badge bg-success' : 'badge bg-secondary';
+}
+
+function pretty(obj) {
+    try { return JSON.stringify(obj, null, 2); } catch (e) { return String(obj); }
+}
+
+document.getElementById('dbg-run').addEventListener('click', () => {
+    const magnet = document.getElementById('dbg-magnet').value.trim();
+    const dir = document.getElementById('dbg-dir').value.trim();
+    if (!magnet) return;
+    const out = document.getElementById('dbg-out');
+    out.textContent = '执行中...';
+    setBadge(false, '执行中');
+
+    fetch(`${basePath}/tool/api.php?action=115_check`, {
+        method: 'POST',
+        headers: {'Content-Type':'application/json'},
+        body: JSON.stringify({ magnet, dir, debug: true }),
+    }).then(r => r.json()).then(res => {
+        out.textContent = pretty(res);
+        setBadge(!!res.exists, res.exists ? '已命中' : '未命中');
+    }).catch(err => {
+        out.textContent = '失败: ' + err.message;
+        setBadge(false, '失败');
+    });
+});
+    </script>
+</body>
+</html>
+

--- a/tool/cli.py
+++ b/tool/cli.py
@@ -797,6 +797,26 @@ def cmd_auto_idle_run(args):
         _print({"skipped": True, "reason": "busy"})
         return
 
+    idle_status_path = os.path.join(paths["status_dir"], "idle_run_status.json")
+    idle_status = read_json(idle_status_path, {"last_run_week": None, "last_run_at": None})
+    try:
+        iso = now.isocalendar()
+        week_key = f"{int(iso.year)}-W{int(iso.week):02d}"
+    except Exception:
+        week_key = None
+    if week_key and idle_status.get("last_run_week") == week_key and not getattr(args, "force", False):
+        _print(
+            {
+                "skipped": True,
+                "reason": "already_ran_this_week",
+                "timezone": tz_name,
+                "now": now.strftime("%Y-%m-%d %H:%M:%S"),
+                "week": week_key,
+                "last_run_at": idle_status.get("last_run_at"),
+            }
+        )
+        return
+
     year = int(getattr(args, "year", None) or now.year)
     default_end_month = now.month - 1
     current_month = int(getattr(args, "end_month", None) or default_end_month)
@@ -852,6 +872,23 @@ def cmd_auto_idle_run(args):
             check_res = _check_year_downloaded(year)
         except Exception as e:
             check_res = {"success": False, "message": str(e)}
+
+    if week_key:
+        try:
+            os.makedirs(paths["status_dir"], exist_ok=True)
+            write_json_atomic(
+                idle_status_path,
+                {
+                    "last_run_week": week_key,
+                    "last_run_at": now.strftime("%Y-%m-%d %H:%M:%S"),
+                    "year": year,
+                    "start_month": start_month,
+                    "end_month": current_month,
+                    "p115_logged_in": bool(login.get("logged_in") is True),
+                },
+            )
+        except Exception:
+            pass
 
     _print(
         {

--- a/tool/cli.py
+++ b/tool/cli.py
@@ -86,6 +86,17 @@ def cmd_games(args):
     if month:
         all_games = [g for g in all_games if g.month == month]
 
+    month_stats = None
+    if year and month:
+        magnet_games = [g for g in all_games if getattr(g, "link", None)]
+        magnet_total = len(magnet_games)
+        magnet_downloaded = sum(1 for g in magnet_games if int(getattr(g, "downloaded", 0) or 0) == 1)
+        month_stats = {
+            "magnet_total": magnet_total,
+            "magnet_downloaded": magnet_downloaded,
+            "all_magnet_downloaded": bool(magnet_total > 0 and magnet_total == magnet_downloaded),
+        }
+
     total = len(all_games)
     start = (page - 1) * per_page
     end = start + per_page
@@ -109,6 +120,7 @@ def cmd_games(args):
             "current_page": page,
             "per_page": per_page,
             "total": total,
+            "month_stats": month_stats,
         }
     )
 
@@ -544,15 +556,15 @@ def cmd_115_check_all_worker(args):
     conn = sqlite3.connect(tool.core.get_db_path())
     tool.core.ensure_getchu_schema(conn)
     cursor = conn.cursor()
+    base_sql = "SELECT date, name, link FROM getchu_games WHERE link IS NOT NULL AND link != '' AND COALESCE(downloaded, 0) = 0"
+    sql_params = []
     if args.year and args.month:
-        cursor.execute(
-            "SELECT date, name, link FROM getchu_games WHERE substr(date, 1, 4) = ? AND CAST(substr(date, 6) AS INTEGER) = ? AND link IS NOT NULL AND link != ''",
-            (str(args.year), int(args.month)),
-        )
-    else:
-        cursor.execute(
-            "SELECT date, name, link FROM getchu_games WHERE link IS NOT NULL AND link != ''"
-        )
+        base_sql += " AND substr(date, 1, 4) = ? AND CAST(substr(date, 6) AS INTEGER) = ?"
+        sql_params = [str(args.year), int(args.month)]
+    elif args.year:
+        base_sql += " AND substr(date, 1, 4) = ?"
+        sql_params = [str(args.year)]
+    cursor.execute(base_sql, sql_params)
     rows = cursor.fetchall()
     conn.close()
 
@@ -603,6 +615,169 @@ def cmd_115_check_all_worker(args):
         "found_downloaded": status["found_downloaded"],
         "errors": status["errors"][:10],
     })
+
+
+def _config_int(config, key, default):
+    v = config.get(key)
+    if v is None or v == "":
+        return default
+    try:
+        return int(v)
+    except Exception:
+        return default
+
+
+def _in_idle_window(config):
+    from datetime import datetime
+
+    tz_name = config.get("idle_timezone") or "Asia/Tokyo"
+    start_hour = _config_int(config, "idle_start_hour", 0)
+    end_hour = _config_int(config, "idle_end_hour", 9)
+    now = None
+    try:
+        from zoneinfo import ZoneInfo
+
+        now = datetime.now(ZoneInfo(tz_name))
+    except Exception:
+        now = datetime.now()
+        tz_name = "local"
+
+    ok = start_hour <= int(now.hour) < end_hour
+    return ok, now, tz_name, start_hour, end_hour
+
+
+def _is_running_status(status):
+    pid = status.get("pid")
+    if not status.get("running") or not pid:
+        return False
+    try:
+        return pid_is_running(int(pid))
+    except Exception:
+        return False
+
+
+def _check_year_downloaded(year):
+    import sqlite3
+    import tool.core
+
+    conn = sqlite3.connect(tool.core.get_db_path())
+    tool.core.ensure_getchu_schema(conn)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT date, name, link FROM getchu_games WHERE substr(date, 1, 4) = ? AND link IS NOT NULL AND link != '' AND COALESCE(downloaded, 0) = 0",
+        (str(year),),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+
+    total = len(rows)
+    checked = 0
+    found_downloaded = 0
+    errors = []
+    for date, name, link in rows:
+        checked += 1
+        try:
+            result, err = _check_magnet_exists_with_timeout(link, 60)
+            if err:
+                errors.append(f"{date}/{name}: {err}")
+                continue
+            if isinstance(result, dict) and result.get("exists"):
+                tool.core.set_downloaded_status(date, name, 1, result.get("infohash_hex"))
+                found_downloaded += 1
+        except Exception as e:
+            errors.append(f"{date}/{name}: {e}")
+    return {
+        "success": True,
+        "total": total,
+        "checked": checked,
+        "found_downloaded": found_downloaded,
+        "errors": errors[:10],
+    }
+
+
+def cmd_auto_idle_run(args):
+    from datetime import datetime
+
+    paths = runtime_paths()
+    config = paths["config"]
+
+    ok, now, tz_name, start_hour, end_hour = _in_idle_window(config)
+    if not ok and not getattr(args, "force", False):
+        _print(
+            {
+                "skipped": True,
+                "reason": "not_idle_time",
+                "timezone": tz_name,
+                "idle_start_hour": start_hour,
+                "idle_end_hour": end_hour,
+                "now": now.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )
+        return
+
+    spider_status = read_json(paths["spider_status_path"], _spider_status_default())
+    download_status = read_json(paths["download_status_path"], _download_status_default())
+    check_all_status = read_json(paths["check_all_status_path"], _check_all_status_default())
+    if _is_running_status(spider_status) or _is_running_status(download_status) or _is_running_status(check_all_status):
+        _print({"skipped": True, "reason": "busy"})
+        return
+
+    year = int(getattr(args, "year", None) or now.year)
+    current_month = int(getattr(args, "end_month", None) or now.month)
+    start_month = int(getattr(args, "start_month", None) or 1)
+    if start_month < 1:
+        start_month = 1
+    if current_month > 12:
+        current_month = 12
+    if start_month > current_month:
+        start_month = current_month
+
+    getchu_ok = False
+    try:
+        getchu_ok = bool(tool.get_all_getchu_games(year, year, start_month, current_month))
+    except Exception:
+        getchu_ok = False
+
+    download_results = []
+    download_ok_all = True
+    for m in range(start_month, current_month + 1):
+        try:
+            ok2 = bool(tool.download_games_by_month(year, m))
+            download_ok_all = download_ok_all and ok2
+            download_results.append({"month": m, "success": ok2})
+        except Exception as e:
+            download_ok_all = False
+            download_results.append({"month": m, "success": False, "error": str(e)})
+
+    login = {"logged_in": False, "user": None, "reason": "not_checked"}
+    check_res = None
+    try:
+        from tool.p115_client import get_login_status
+
+        login = get_login_status()
+    except Exception as e:
+        login = {"logged_in": False, "user": None, "reason": str(e)}
+
+    if login.get("logged_in") is True:
+        try:
+            check_res = _check_year_downloaded(year)
+        except Exception as e:
+            check_res = {"success": False, "message": str(e)}
+
+    _print(
+        {
+            "success": True,
+            "timezone": tz_name,
+            "now": now.strftime("%Y-%m-%d %H:%M:%S"),
+            "year": year,
+            "start_month": start_month,
+            "end_month": current_month,
+            "getchu": {"success": getchu_ok},
+            "download_links": {"success": download_ok_all, "months": download_results},
+            "p115_login": login,
+            "p115_check": check_res,
+        }
+    )
 
 
 def build_parser():
@@ -716,6 +891,16 @@ def build_parser():
     p_delete.add_argument("--date", type=str, required=True)
     p_delete.add_argument("--name", type=str, required=True)
     p_delete.set_defaults(func=cmd_delete_game)
+
+    p_auto = sub.add_parser("auto")
+    auto_sub = p_auto.add_subparsers(dest="action", required=True)
+
+    p_idle = auto_sub.add_parser("idle_run")
+    p_idle.add_argument("--force", action="store_true")
+    p_idle.add_argument("--year", type=int)
+    p_idle.add_argument("--start-month", type=int, dest="start_month")
+    p_idle.add_argument("--end-month", type=int, dest="end_month")
+    p_idle.set_defaults(func=cmd_auto_idle_run)
 
     return parser
 

--- a/tool/cli.py
+++ b/tool/cli.py
@@ -60,6 +60,76 @@ def cmd_years(args):
     years = tool.get_years_list()
     _print({"years": years})
 
+
+def cmd_calendar(args):
+    import sqlite3
+    from datetime import datetime
+    import tool.core
+
+    paths = runtime_paths()
+    base_year = int(args.year) if getattr(args, "year", None) else datetime.now().year
+    start_year = base_year - 2
+    end_year = base_year
+
+    conn = sqlite3.connect(tool.core.get_db_path())
+    tool.core.ensure_getchu_schema(conn)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT
+            substr(date, 1, 4) as year,
+            CAST(substr(date, 6, 2) AS INTEGER) as month,
+            COUNT(*) as total,
+            SUM(CASE WHEN link IS NOT NULL AND link != '' THEN 1 ELSE 0 END) as magnet_total,
+            SUM(CASE WHEN link IS NOT NULL AND link != '' AND COALESCE(downloaded, 0) = 1 THEN 1 ELSE 0 END) as magnet_downloaded,
+            SUM(CASE WHEN link IS NOT NULL AND link != '' AND COALESCE(submitted_115, 0) = 1 THEN 1 ELSE 0 END) as magnet_submitted
+        FROM getchu_games
+        WHERE CAST(substr(date, 1, 4) AS INTEGER) BETWEEN ? AND ?
+        GROUP BY year, month
+        ORDER BY year DESC, month DESC
+        """,
+        (int(start_year), int(end_year)),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+
+    stats = {}
+    for y, m, total, magnet_total, magnet_downloaded, magnet_submitted in rows:
+        yy = int(y)
+        mm = int(m)
+        total = int(total or 0)
+        magnet_total = int(magnet_total or 0)
+        magnet_downloaded = int(magnet_downloaded or 0)
+        magnet_submitted = int(magnet_submitted or 0)
+        stats[(yy, mm)] = {
+            "has_data": total > 0,
+            "total": total,
+            "magnet_total": magnet_total,
+            "magnet_downloaded": magnet_downloaded,
+            "magnet_submitted": magnet_submitted,
+            "all_magnet_downloaded": bool(magnet_total > 0 and magnet_total == magnet_downloaded),
+            "all_magnet_submitted": bool(magnet_total > 0 and magnet_total == magnet_submitted),
+        }
+
+    years = []
+    for y in range(end_year, start_year - 1, -1):
+        months = []
+        for m in range(1, 13):
+            st = stats.get((y, m)) or {
+                "has_data": False,
+                "total": 0,
+                "magnet_total": 0,
+                "magnet_downloaded": 0,
+                "magnet_submitted": 0,
+                "all_magnet_downloaded": False,
+                "all_magnet_submitted": False,
+            }
+            months.append({"month": m, **st})
+        years.append({"year": y, "months": months})
+
+    _print({"base_year": base_year, "start_year": start_year, "end_year": end_year, "years": years})
+
+
 def cmd_latest_month(args):
     games = tool.get_games_data()
     if not games:
@@ -114,6 +184,7 @@ def cmd_games(args):
                     "nyaa_name": g.nyaa_name,
                     "comment": g.comment,
                     "downloaded": g.downloaded,
+                    "submitted_115": getattr(g, "submitted_115", 0),
                 }
                 for g in games_data
             ],
@@ -521,6 +592,10 @@ def cmd_update_game(args):
         kwargs["new_downloaded"] = args.new_downloaded
     if args.new_nyaa_name is not None:
         kwargs["new_nyaa_name"] = args.new_nyaa_name
+    if getattr(args, "new_submitted_115", None) is not None:
+        kwargs["new_submitted_115"] = args.new_submitted_115
+    if getattr(args, "new_submitted_pick_code", None) is not None:
+        kwargs["new_submitted_pick_code"] = args.new_submitted_pick_code
     ok = tool.core.update_game_record(**kwargs)
     _print({"success": ok, "message": "更新成功" if ok else "未找到匹配记录"})
 
@@ -787,6 +862,10 @@ def build_parser():
     p_years = sub.add_parser("years")
     p_years.set_defaults(func=cmd_years)
 
+    p_calendar = sub.add_parser("calendar")
+    p_calendar.add_argument("--year", type=int)
+    p_calendar.set_defaults(func=cmd_calendar)
+
     p_latest = sub.add_parser("latest_month")
     p_latest.set_defaults(func=cmd_latest_month)
 
@@ -885,6 +964,8 @@ def build_parser():
     p_update.add_argument("--new-link", type=str)
     p_update.add_argument("--new-downloaded", type=int, choices=[0, 1])
     p_update.add_argument("--new-nyaa-name", type=str)
+    p_update.add_argument("--new-submitted-115", type=int, choices=[0, 1], dest="new_submitted_115")
+    p_update.add_argument("--new-submitted-pick-code", type=str, dest="new_submitted_pick_code")
     p_update.set_defaults(func=cmd_update_game)
 
     p_delete = sub.add_parser("delete_game")

--- a/tool/cli.py
+++ b/tool/cli.py
@@ -421,7 +421,7 @@ def cmd_115_check(args):
         from tool.p115_client import check_magnet_exists
         magnet = args.magnet
         save_path = args.dir or ""
-        _print(check_magnet_exists(magnet, save_path))
+        _print(check_magnet_exists(magnet, save_path, debug=bool(getattr(args, "debug", False))))
     except Exception as e:
         _print({"status": "error", "message": f"115模块加载失败: {e}"})
 
@@ -929,6 +929,7 @@ def build_parser():
     p_115_check = _115_sub.add_parser("check")
     p_115_check.add_argument("--magnet", type=str, required=True)
     p_115_check.add_argument("--dir", type=str, default="")
+    p_115_check.add_argument("--debug", action="store_true")
     p_115_check.set_defaults(func=cmd_115_check)
 
     p_115_submit = _115_sub.add_parser("submit")

--- a/tool/cli.py
+++ b/tool/cli.py
@@ -798,12 +798,26 @@ def cmd_auto_idle_run(args):
         return
 
     year = int(getattr(args, "year", None) or now.year)
-    current_month = int(getattr(args, "end_month", None) or now.month)
+    default_end_month = now.month - 1
+    current_month = int(getattr(args, "end_month", None) or default_end_month)
     start_month = int(getattr(args, "start_month", None) or 1)
     if start_month < 1:
         start_month = 1
     if current_month > 12:
         current_month = 12
+    if current_month < 1:
+        _print(
+            {
+                "skipped": True,
+                "reason": "no_months_to_process",
+                "timezone": tz_name,
+                "now": now.strftime("%Y-%m-%d %H:%M:%S"),
+                "year": year,
+                "start_month": start_month,
+                "end_month": current_month,
+            }
+        )
+        return
     if start_month > current_month:
         start_month = current_month
 

--- a/tool/cli.py
+++ b/tool/cli.py
@@ -818,7 +818,15 @@ def cmd_auto_idle_run(args):
         return
 
     year = int(getattr(args, "year", None) or now.year)
-    default_end_month = now.month - 1
+
+    # 重新获取当前时间用于月份范围计算，避免与闲时窗口的 now 混淆
+    try:
+        from zoneinfo import ZoneInfo
+        _now = datetime.now(ZoneInfo(tz_name))
+    except Exception:
+        _now = datetime.now()
+
+    default_end_month = _now.month - 1
     current_month = int(getattr(args, "end_month", None) or default_end_month)
     start_month = int(getattr(args, "start_month", None) or 1)
     if start_month < 1:

--- a/tool/core.py
+++ b/tool/core.py
@@ -116,6 +116,8 @@ def ensure_getchu_schema(conn):
             comment TEXT,
             downloaded INTEGER DEFAULT 0,
             infohash_hex TEXT,
+            submitted_115 INTEGER DEFAULT 0,
+            submitted_pick_code TEXT,
             PRIMARY KEY (date, name)
         )
         """
@@ -128,6 +130,11 @@ def ensure_getchu_schema(conn):
         cursor.execute("ALTER TABLE getchu_games ADD COLUMN downloaded INTEGER DEFAULT 0")
     if "infohash_hex" not in cols:
         cursor.execute("ALTER TABLE getchu_games ADD COLUMN infohash_hex TEXT")
+    if "submitted_115" not in cols:
+        cursor.execute("ALTER TABLE getchu_games ADD COLUMN submitted_115 INTEGER DEFAULT 0")
+    if "submitted_pick_code" not in cols:
+        cursor.execute("ALTER TABLE getchu_games ADD COLUMN submitted_pick_code TEXT")
+    cursor.execute("UPDATE getchu_games SET submitted_115 = 1 WHERE COALESCE(downloaded, 0) = 1 AND COALESCE(submitted_115, 0) = 0")
     conn.commit()
 
 
@@ -149,7 +156,25 @@ def set_downloaded_status(date, name, downloaded=1, infohash_hex=None, db_path=N
     conn.close()
 
 
-def update_game_record(date, name, new_date=None, new_name=None, new_company=None, new_link=None, new_downloaded=None, new_nyaa_name=None, db_path=None):
+def set_submitted_status(date, name, submitted_115=1, submitted_pick_code=None, db_path=None):
+    conn = sqlite3.connect(db_path or get_db_path())
+    ensure_getchu_schema(conn)
+    cursor = conn.cursor()
+    if submitted_pick_code is not None:
+        cursor.execute(
+            "UPDATE getchu_games SET submitted_115 = ?, submitted_pick_code = ? WHERE date = ? AND name = ?",
+            (1 if submitted_115 else 0, submitted_pick_code, date, name),
+        )
+    else:
+        cursor.execute(
+            "UPDATE getchu_games SET submitted_115 = ? WHERE date = ? AND name = ?",
+            (1 if submitted_115 else 0, date, name),
+        )
+    conn.commit()
+    conn.close()
+
+
+def update_game_record(date, name, new_date=None, new_name=None, new_company=None, new_link=None, new_downloaded=None, new_nyaa_name=None, new_submitted_115=None, new_submitted_pick_code=None, db_path=None):
     conn = sqlite3.connect(db_path or get_db_path())
     ensure_getchu_schema(conn)
     cursor = conn.cursor()
@@ -166,6 +191,10 @@ def update_game_record(date, name, new_date=None, new_name=None, new_company=Non
         fields["downloaded"] = 1 if new_downloaded else 0
     if new_nyaa_name is not None:
         fields["nyaa_name"] = new_nyaa_name
+    if new_submitted_115 is not None:
+        fields["submitted_115"] = 1 if new_submitted_115 else 0
+    if new_submitted_pick_code is not None:
+        fields["submitted_pick_code"] = new_submitted_pick_code
     if not fields:
         conn.close()
         return False
@@ -428,7 +457,9 @@ def get_games_data():
             nyaa_name,
             comment,
             COALESCE(downloaded, 0) as downloaded,
-            infohash_hex
+            infohash_hex,
+            COALESCE(submitted_115, 0) as submitted_115,
+            submitted_pick_code
         FROM getchu_games
         ORDER BY year DESC, month DESC
         """
@@ -444,6 +475,8 @@ def get_games_data():
             row[6],
             row[7],
             row[8],
+            row[9],
+            row[10],
         )
         for row in cursor.fetchall()
     ]

--- a/tool/data.php
+++ b/tool/data.php
@@ -86,6 +86,7 @@
             <div class="navbar-nav">
                 <a class="nav-link" href="<?= $base ?>/index.php">首页</a>
                 <a class="nav-link active" href="<?= $base ?>/tool/data.php">数据展示</a>
+                <a class="nav-link" href="<?= $base ?>/calendar.php">年历</a>
             </div>
         </div>
     </nav>
@@ -281,16 +282,18 @@ function updateTable(data) {
 
     tbody.innerHTML = data.map(game => {
         const isDownloaded = game.downloaded == 1;
-        const rowClass = isDownloaded ? ' class="table-success"' : '';
+        const isSubmitted = game.submitted_115 == 1;
+        const rowClass = isDownloaded ? ' class="table-success"' : isSubmitted ? ' class="table-info"' : '';
         const dateFull = `${game.year}-${String(game.month).padStart(2, '0')}`;
         const magnet = game.download_url || '';
         const encName = encodeURIComponent(game.name);
         const encNyaa = game.nyaa_name ? encodeURIComponent(game.nyaa_name) : '';
         return `
-        <tr${rowClass} data-date="${dateFull}" data-name="${encName}" data-magnet="${encodeURIComponent(magnet)}" data-downloaded="${game.downloaded || 0}" data-nyaa-name="${encNyaa}">
+        <tr${rowClass} data-date="${dateFull}" data-name="${encName}" data-magnet="${encodeURIComponent(magnet)}" data-downloaded="${game.downloaded || 0}" data-submitted-115="${game.submitted_115 || 0}" data-nyaa-name="${encNyaa}">
             <td class="check-col text-center">
                 ${!magnet ? '<span class="text-muted small">-</span>'
                     : isDownloaded ? '<span class="badge bg-success">已下载</span>'
+                    : isSubmitted ? '<span class="badge bg-primary">已提交</span>'
                     : `<input type="checkbox" class="game-checkbox" checked onchange="handleCheckboxChange(this)">`
                 }
             </td>
@@ -300,7 +303,7 @@ function updateTable(data) {
             <td class="actions-col">
                 ${magnet ?
                     `<div class="btn-group actions-group" role="group">
-                        <button type="button" class="btn btn-success btn-sm btn-115-submit"
+                        <button type="button" class="btn btn-success btn-sm btn-115-submit"${isSubmitted ? ' disabled' : ''}
                             data-magnet="${encodeURIComponent(magnet)}"
                             data-year="${game.year}">115云下载</button>
                         <button type="button" class="btn btn-outline-secondary btn-sm magnet-check-btn"
@@ -549,6 +552,20 @@ function batch115Download() {
             if (res.success) {
                 success++;
                 results.push({ ok: true, name });
+                const date = tr.dataset.date || '';
+                const rawName = tr.dataset.name ? decodeURIComponent(tr.dataset.name) : '';
+                if (date && rawName) {
+                    fetch(`${basePath}/tool/api.php?action=update_game`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            date,
+                            old_name: rawName,
+                            new_submitted_115: 1,
+                            new_submitted_pick_code: res.pick_code || '',
+                        }),
+                    }).catch(() => {});
+                }
             } else {
                 fail++;
                 results.push({ ok: false, name, reason: res.message || '未知错误' });
@@ -795,6 +812,7 @@ document.getElementById('data-115-logout-btn').addEventListener('click', () => {
 document.querySelector('#gamesTable tbody').addEventListener('click', (e) => {
     const btn = e.target.closest('.btn-115-submit');
     if (!btn) return;
+    const tr = btn.closest('tr');
     const magnet = decodeURIComponent(btn.dataset.magnet || '');
     const year = btn.dataset.year || '';
     if (!magnet) return;
@@ -808,6 +826,24 @@ document.querySelector('#gamesTable tbody').addEventListener('click', (e) => {
         body: JSON.stringify({magnet, dir: savePath}),
     }).then(r => r.json()).then(res => {
         if (res.success) {
+            const date = tr ? (tr.dataset.date || '') : '';
+            const rawName = tr && tr.dataset.name ? decodeURIComponent(tr.dataset.name) : '';
+            if (date && rawName) {
+                fetch(`${basePath}/tool/api.php?action=update_game`, {
+                    method: 'POST',
+                    headers: {'Content-Type':'application/json'},
+                    body: JSON.stringify({
+                        date,
+                        old_name: rawName,
+                        new_submitted_115: 1,
+                        new_submitted_pick_code: res.pick_code || '',
+                    }),
+                }).then(() => {
+                    loadPage(currentPage);
+                }).catch(() => {
+                    loadPage(currentPage);
+                });
+            }
             btn.className = 'btn btn-success btn-sm disabled';
             btn.textContent = '✓已提交';
             setTimeout(() => { btn.disabled = false; btn.className = 'btn btn-success btn-sm btn-115-submit'; btn.textContent = origText; }, 3000);
@@ -919,7 +955,12 @@ document.getElementById('modal-submit-btn').addEventListener('click', function()
                 fetch(`${basePath}/tool/api.php?action=update_game`, {
                     method: 'POST',
                     headers: {'Content-Type':'application/json'},
-                    body: JSON.stringify({date, old_name: name, new_downloaded: 1}),
+                    body: JSON.stringify({
+                        date,
+                        old_name: name,
+                        new_submitted_115: 1,
+                        new_submitted_pick_code: res.pick_code || '',
+                    }),
                 }).then(() => {
                     bootstrap.Modal.getInstance(document.getElementById('checkModal')).hide();
                     loadPage(currentPage);

--- a/tool/data.php
+++ b/tool/data.php
@@ -202,6 +202,7 @@
                     <div class="d-flex gap-2 mb-3">
                         <button id="modal-check-btn" class="btn btn-outline-info btn-sm">检查115是否存在</button>
                         <button id="modal-submit-btn" class="btn btn-success btn-sm">提交到115</button>
+                        <a id="modal-debug-link" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">调试</a>
                     </div>
                     <div id="modal-result" class="small" style="white-space:pre-wrap;word-break:break-all;"></div>
                 </div>
@@ -889,6 +890,11 @@ function openCheckModal(magnet, name, year, date) {
     document.getElementById('modal-game-name').textContent = name || '-';
     document.getElementById('modal-magnet').value = magnet;
     document.getElementById('modal-save-path').value = `/GAL/GAL-${year}`;
+    const debugLink = document.getElementById('modal-debug-link');
+    if (debugLink) {
+        const dir = `/GAL/GAL-${year}`;
+        debugLink.href = `${basePath}/tool/check_debug.php?magnet=${encodeURIComponent(magnet)}&dir=${encodeURIComponent(dir)}`;
+    }
     document.getElementById('modal-result').textContent = '';
     document.getElementById('modal-check-btn').disabled = false;
     document.getElementById('modal-submit-btn').disabled = false;

--- a/tool/data.php
+++ b/tool/data.php
@@ -447,21 +447,33 @@ function initMonthPicker() {
 window.addEventListener('DOMContentLoaded', () => {
     initMonthPicker();
     data115CheckLoginStatus();
-    fetch(`${basePath}/tool/api.php?action=latest_month`)
-        .then(r => r.json())
-        .then((res) => {
-            const y = res && res.year ? parseInt(res.year, 10) : null;
-            const m = res && res.month ? parseInt(res.month, 10) : null;
-            if (y && m) {
-                suppressDateChangeLoad = true;
-                $('#month-picker').datepicker('setDate', new Date(y, m - 1, 1));
-                suppressDateChangeLoad = false;
-            }
-            loadPage(1);
-        })
-        .catch(() => {
-            loadPage(1);
-        });
+
+    const params = new URLSearchParams(window.location.search);
+    const paramYear = params.get('year');
+    const paramMonth = params.get('month');
+
+    if (paramYear && paramMonth) {
+        suppressDateChangeLoad = true;
+        $('#month-picker').datepicker('setDate', new Date(parseInt(paramYear, 10), parseInt(paramMonth, 10) - 1, 1));
+        suppressDateChangeLoad = false;
+        loadPage(1);
+    } else {
+        fetch(`${basePath}/tool/api.php?action=latest_month`)
+            .then(r => r.json())
+            .then((res) => {
+                const y = res && res.year ? parseInt(res.year, 10) : null;
+                const m = res && res.month ? parseInt(res.month, 10) : null;
+                if (y && m) {
+                    suppressDateChangeLoad = true;
+                    $('#month-picker').datepicker('setDate', new Date(y, m - 1, 1));
+                    suppressDateChangeLoad = false;
+                }
+                loadPage(1);
+            })
+            .catch(() => {
+                loadPage(1);
+            });
+    }
 });
 
 document.getElementById('prev-page').addEventListener('click', () => {

--- a/tool/data.php
+++ b/tool/data.php
@@ -146,7 +146,10 @@
         <div class="card">
             <div class="card-header d-flex align-items-center justify-content-between">
                 <div class="fw-semibold">游戏列表</div>
-                <div id="page-info" class="text-muted small">第1页</div>
+                <div class="d-flex align-items-center gap-2">
+                    <span id="month-all-downloaded-badge" class="badge bg-success" style="display:none;">全部已下载</span>
+                    <div id="page-info" class="text-muted small">第1页</div>
+                </div>
             </div>
             <div class="table-responsive">
                 <table class="table table-striped table-hover align-middle mb-0" id="gamesTable">
@@ -329,8 +332,17 @@ function showEmptyMessage(message) {
     const tbody = document.querySelector('#gamesTable tbody');
     tbody.innerHTML = `<tr><td colspan="5" class="text-center text-muted py-4">${message}</td></tr>`;
     document.getElementById('page-info').textContent = '';
+    updateMonthAllDownloadedBadge(null, null);
     document.getElementById('prev-page').disabled = true;
     document.getElementById('next-page').disabled = true;
+}
+
+function updateMonthAllDownloadedBadge(monthValue, monthStats) {
+    const badge = document.getElementById('month-all-downloaded-badge');
+    if (!badge) return;
+    const hasMonth = !!(monthValue && parseMonthValue(monthValue));
+    const ok = !!(hasMonth && monthStats && monthStats.all_magnet_downloaded);
+    badge.style.display = ok ? '' : 'none';
 }
 
 function loadPage(page) {
@@ -363,6 +375,7 @@ function loadPage(page) {
 
             updateTable(res.data);
             updateToggleButtonText();
+            updateMonthAllDownloadedBadge(monthValue, res.month_stats);
 
             currentPage = res.current_page;
             document.getElementById('page-info').textContent =

--- a/tool/data.php
+++ b/tool/data.php
@@ -494,8 +494,13 @@ function updateToggleButtonText() {
 
 function updateBatchButtons() {
     const anyChecked = Array.from(document.querySelectorAll('#gamesTable tbody input.game-checkbox')).some(cb => cb.checked);
+    const anyNeedCheck = Array.from(document.querySelectorAll('#gamesTable tbody tr')).some((tr) => {
+        const magnet = tr.dataset.magnet ? decodeURIComponent(tr.dataset.magnet) : '';
+        const downloaded = parseInt(tr.dataset.downloaded || '0', 10) === 1;
+        return !!magnet && !downloaded;
+    });
     document.getElementById('batch-115-download').disabled = !anyChecked;
-    document.getElementById('batch-115-check').disabled = !anyChecked;
+    document.getElementById('batch-115-check').disabled = !anyNeedCheck;
 }
 
 function handleCheckboxChange(checkbox) {

--- a/tool/models.py
+++ b/tool/models.py
@@ -1,5 +1,5 @@
 class GetchuGame:
-    def __init__(self, date, name, company, size=None, link=None, nyaa_name=None, comment=None, downloaded=0, infohash_hex=None):
+    def __init__(self, date, name, company, size=None, link=None, nyaa_name=None, comment=None, downloaded=0, infohash_hex=None, submitted_115=0, submitted_pick_code=None):
         self.date = date
         self.year, self.month = map(int, date.split('-'))
         self.name = name
@@ -10,6 +10,8 @@ class GetchuGame:
         self.comment = comment
         self.downloaded = downloaded
         self.infohash_hex = infohash_hex
+        self.submitted_115 = submitted_115
+        self.submitted_pick_code = submitted_pick_code
 
     def __str__(self):
         return f"GetchuGame(date={self.date}, name='{self.name}', company='{self.company}')"
@@ -30,4 +32,3 @@ class NyaaData:
 
     def __repr__(self):
         return self.__str__()
-

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -587,7 +587,6 @@ def check_magnet_exists(magnet, save_path, debug=False):
     matched_files = []
     in_offline = False
     confidence = "none"
-    matched_in_other_dir = False
 
     dbg = None
     if debug:
@@ -735,38 +734,6 @@ def check_magnet_exists(magnet, save_path, debug=False):
                             ],
                         })
 
-        matched_in_other_dir = False
-        if not matched_files and cid:
-            for kw in keywords[:8]:
-                files2 = search_files(kw, 0)
-                if dbg is not None:
-                    dbg["steps"].append({"stage": "search_files", "mode": "global_keyword", "query": kw, "cid": 0, "result_len": len(files2)})
-                for f in files2:
-                    fname = f.get("n", "") if isinstance(f, dict) else ""
-                    norm_fname = _normalize_for_comparison(fname)
-                    if _names_match(norm_dn, norm_fname):
-                        matched_in_other_dir = True
-                        matched_files.append({
-                            "name": fname,
-                            "size": f.get("s") if isinstance(f, dict) else None,
-                            "pick_code": f.get("pc") if isinstance(f, dict) else None,
-                            "cid": f.get("cid") if isinstance(f, dict) else None,
-                        })
-                if dbg is not None:
-                    dbg["steps"].append({
-                        "stage": "match_compare",
-                        "mode": "global_keyword",
-                        "query": kw,
-                        "matched_len": len(matched_files),
-                        "sample_files": [
-                            {"name": (it.get("n") or ""), "norm": _normalize_for_comparison(it.get("n") or "")}
-                            for it in (files2[:5] if isinstance(files2, list) else [])
-                            if isinstance(it, dict)
-                        ],
-                    })
-                if matched_files:
-                    break
-
         if not matched_files and not in_offline and infohash_hex:
             try:
                 broad = search_files(infohash_hex[:12], cid or 0)
@@ -806,8 +773,6 @@ def check_magnet_exists(magnet, save_path, debug=False):
         "in_offline_tasks": in_offline,
         "dn": dn,
     }
-    if matched_in_other_dir:
-        out["matched_in_other_dir"] = True
     if dbg is not None:
         dbg["result"] = {"matched_len": len(matched_files), "in_offline": in_offline, "confidence": confidence}
         out["debug"] = dbg

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -398,7 +398,7 @@ def _normalize_for_comparison(name):
         r'\b(disc|disk)\s*\d+\b',
         r'\[(\d{7,})\]',
         r'\[\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*\]',
-        r'\b(?:crack|patch|update)\b',
+        r'\b(?:crack|patch|update|updated)\b',
         r'(?:パッケージ版|ダウンロード版|dl\s*版|通常版)',
         r'\[\s*\]',
         r'\bmini\s*adv\b',
@@ -412,6 +412,17 @@ _DATE_PREFIX_RE = re.compile(r'^\[(\d{6})\]')
 _DATE_BRACKET_RE = re.compile(r'^\[\d{6}\]\s*')
 
 
+def _leading_date_codes(s):
+    codes = []
+    while True:
+        m = _DATE_PREFIX_RE.match(s or "")
+        if not m:
+            break
+        codes.append(m.group(1))
+        s = (s or "")[m.end():]
+    return codes
+
+
 def _names_match(norm_dn, norm_fname):
     if not norm_dn or not norm_fname:
         return False
@@ -421,17 +432,21 @@ def _names_match(norm_dn, norm_fname):
     fn_compact = norm_fname.replace(" ", "")
     if dn_compact and fn_compact and (dn_compact in fn_compact or fn_compact in dn_compact):
         return True
-    m_dn = _DATE_PREFIX_RE.match(norm_dn)
-    m_fn = _DATE_PREFIX_RE.match(norm_fname)
-    if not m_dn or not m_fn:
+    dn_codes = _leading_date_codes(norm_dn)
+    fn_codes = _leading_date_codes(norm_fname)
+    common = None
+    for c in dn_codes:
+        if c in fn_codes:
+            common = c
+            break
+    if not common:
         return False
-    if m_dn.group(1) != m_fn.group(1):
-        return False
-    dn_no_date = _DATE_BRACKET_RE.sub('', norm_dn, count=1)
-    fn_no_date = _DATE_BRACKET_RE.sub('', norm_fname, count=1)
+
+    dn_no_date = re.sub(r'^\[' + re.escape(common) + r'\]\s*', '', norm_dn, count=1)
+    fn_no_date = re.sub(r'^\[' + re.escape(common) + r'\]\s*', '', norm_fname, count=1)
+    dn_no_date = re.sub(r'^(?:\[[^\]]+\]\s*)+', '', dn_no_date).strip()
+    fn_no_date = re.sub(r'^(?:\[[^\]]+\]\s*)+', '', fn_no_date).strip()
     if dn_no_date and fn_no_date:
-        dn_no_date = re.sub(r'^(?:\[[^\]]+\]\s*)+', '', dn_no_date).strip()
-        fn_no_date = re.sub(r'^(?:\[[^\]]+\]\s*)+', '', fn_no_date).strip()
         if dn_no_date in fn_no_date or fn_no_date in dn_no_date:
             return True
         dn2 = dn_no_date.replace(" ", "")

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -425,12 +425,18 @@ def _names_match(norm_dn, norm_fname):
     m_fn = _DATE_PREFIX_RE.match(norm_fname)
     if not m_dn or not m_fn:
         return False
-    if m_dn.group(1) == m_fn.group(1):
+    if m_dn.group(1) != m_fn.group(1):
         return False
     dn_no_date = _DATE_BRACKET_RE.sub('', norm_dn, count=1)
     fn_no_date = _DATE_BRACKET_RE.sub('', norm_fname, count=1)
     if dn_no_date and fn_no_date:
-        return dn_no_date in fn_no_date or fn_no_date in dn_no_date
+        dn_no_date = re.sub(r'^(?:\[[^\]]+\]\s*)+', '', dn_no_date).strip()
+        fn_no_date = re.sub(r'^(?:\[[^\]]+\]\s*)+', '', fn_no_date).strip()
+        if dn_no_date in fn_no_date or fn_no_date in dn_no_date:
+            return True
+        dn2 = dn_no_date.replace(" ", "")
+        fn2 = fn_no_date.replace(" ", "")
+        return dn2 in fn2 or fn2 in dn2
     return False
 
 

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -387,6 +387,7 @@ def _normalize_for_comparison(name):
     if first_bracket > 0:
         name = name[first_bracket:]
     name = re.split(r'\s*\+\s*', name)[0]
+    name = re.sub(r'\]\s+\[', '][', name)
     name = name.lower()
     name = name.replace('・', '').replace('♡', '').replace('❤', '').replace('♥', '')
     name = name.replace('~', '').replace('～', '').replace('〜', '').replace('！', '').replace('：', '')

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -390,7 +390,7 @@ def _normalize_for_comparison(name):
     name = re.sub(r'\]\s+\[', '][', name)
     name = name.lower()
     name = name.translate(str.maketrans('０１２３４５６７８９', '0123456789'))
-    for ch in '・♡❤♥~～〜！!？?：:『』「」－–—−―ｰ':
+    for ch in '・♡❤♥~～〜！!？?：:『』「」－–—−―ｰ‐‑‒':
         name = name.replace(ch, '')
     for pattern in (
         r'\(\s*mdf\s*\+\s*mds\s*\)',
@@ -398,6 +398,8 @@ def _normalize_for_comparison(name):
         r'\b(disc|disk)\s*\d+\b',
         r'\[(\d{7,})\]',
         r'\[\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*\]',
+        r'(?i)\bdvd\s*version\b',
+        r'(?i)\bdvd\b',
         r'\b(?:crack|patch|update|updated)\b',
         r'(?:パッケージ版|ダウンロード版|dl\s*版|通常版)',
         r'\[\s*\]',

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -390,16 +390,19 @@ def _normalize_for_comparison(name):
     name = re.sub(r'\]\s+\[', '][', name)
     name = name.lower()
     name = name.translate(str.maketrans('０１２３４５６７８９', '0123456789'))
-    name = name.replace('・', '').replace('♡', '').replace('❤', '').replace('♥', '')
-    name = name.replace('~', '').replace('～', '').replace('〜', '').replace('！', '').replace('：', '').replace(':', '')
-    name = re.sub(r'\(\s*mdf\s*\+\s*mds\s*\)', '', name)
-    name = re.sub(r'\(\s*mdf\+mds\s*\)', '', name)
-    name = re.sub(r'\b(disc|disk)\s*\d+\b', '', name)
-    name = re.sub(r'\[(\d{7,})\]', '', name)
-    name = re.sub(r'\[\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*\]', '', name)
-    name = re.sub(r'\b(?:crack|patch|update)\b', '', name)
-    name = re.sub(r'(?:パッケージ版|ダウンロード版|dl\s*版|通常版)', '', name)
-    name = re.sub(r'\bmini\s*adv\b', '', name)
+    for ch in '・♡❤♥~～〜！!？?：:':
+        name = name.replace(ch, '')
+    for pattern in (
+        r'\(\s*mdf\s*\+\s*mds\s*\)',
+        r'\(\s*mdf\+mds\s*\)',
+        r'\b(disc|disk)\s*\d+\b',
+        r'\[(\d{7,})\]',
+        r'\[\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*\]',
+        r'\b(?:crack|patch|update)\b',
+        r'(?:パッケージ版|ダウンロード版|dl\s*版|通常版)',
+        r'\bmini\s*adv\b',
+    ):
+        name = re.sub(pattern, '', name)
     name = re.sub(r'[\s\-_.]+', ' ', name).strip()
     return name
 

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -389,8 +389,9 @@ def _normalize_for_comparison(name):
     name = re.split(r'\s*\+\s*', name)[0]
     name = name.lower()
     name = name.replace('・', '').replace('♡', '').replace('❤', '').replace('♥', '')
-    name = name.replace('~', '').replace('～', '').replace('！', '').replace('：', '')
+    name = name.replace('~', '').replace('～', '').replace('〜', '').replace('！', '').replace('：', '')
     name = re.sub(r'\(\s*mdf\s*\+\s*mds\s*\)', '', name)
+    name = re.sub(r'\(\s*mdf\+mds\s*\)', '', name)
     name = re.sub(r'\b(disc|disk)\s*\d+\b', '', name)
     name = re.sub(r'\[(\d{7,})\]', '', name)
     name = re.sub(r'\[\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*\]', '', name)

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -393,7 +393,7 @@ def _normalize_for_comparison(name):
     name = re.sub(r'\(\s*mdf\s*\+\s*mds\s*\)', '', name)
     name = re.sub(r'\b(disc|disk)\s*\d+\b', '', name)
     name = re.sub(r'\[(\d{7,})\]', '', name)
-    name = re.sub(r'\[\s*\d+(?:\.\d+)?\s*(?:kb|mb|gb|tb)\s*\]', '', name)
+    name = re.sub(r'\[\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*\]', '', name)
     name = re.sub(r'\b(?:crack|patch|update)\b', '', name)
     name = re.sub(r'(?:パッケージ版|ダウンロード版|dl\s*版|通常版)', '', name)
     name = re.sub(r'\bmini\s*adv\b', '', name)
@@ -417,7 +417,7 @@ def _search_keyword_from_dn(dn):
             continue
         if re.fullmatch(r'\d{7,}', v):
             continue
-        if re.fullmatch(r'\s*\d+(?:\.\d+)?\s*(?:kb|mb|gb|tb)\s*', v.lower()):
+        if re.fullmatch(r'\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*', v.lower()):
             continue
         rest.append(v)
     if date_bracket and rest:

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -431,6 +431,60 @@ def _search_keyword_from_dn(dn):
     return name.strip()[:30]
 
 
+def _extra_keywords_from_dn(dn):
+    name = (dn or "").strip()
+    first_bracket = name.find('[')
+    if first_bracket > 0:
+        name = name[first_bracket:]
+
+    brackets = re.findall(r'\[([^\]]+)\]', name)
+    date_code = ""
+    company = ""
+    digits7 = ""
+    for raw in brackets:
+        v = raw.strip()
+        if not date_code and re.fullmatch(r'\d{6}', v):
+            date_code = v
+            continue
+        if not digits7 and re.fullmatch(r'\d{7,}', v):
+            digits7 = v
+            continue
+        if not company and v and not re.fullmatch(r'\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*', v.lower()):
+            company = v
+
+    title = re.sub(r'\[[^\]]+\]', ' ', name)
+    title = re.split(r'\s*\+\s*', title)[0]
+    title = re.sub(r'\[\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*\]', ' ', title, flags=re.I)
+    title = re.sub(r'(?:パッケージ版|ダウンロード版|dl\s*版|通常版)', ' ', title, flags=re.I)
+    title = re.sub(r'[\(\（].*?[\)\）]', ' ', title)
+    title = re.sub(r'[\s\-_.]+', ' ', title).strip()
+    if len(title) > 24:
+        title = title[:24].strip()
+
+    kws = []
+    if digits7:
+        kws.append(f"[{digits7}]")
+    if date_code:
+        kws.append(f"[{date_code}]")
+    if title and date_code:
+        kws.append(f"[{date_code}] {title}")
+        kws.append(f"[{date_code}]{title}")
+    if title and company:
+        kws.append(f"[{company}] {title}")
+        kws.append(f"[{company}]{title}")
+    if title:
+        kws.append(title)
+
+    uniq = []
+    for it in kws:
+        it = (it or "").strip()
+        if not it:
+            continue
+        if it not in uniq:
+            uniq.append(it)
+    return uniq
+
+
 def check_magnet_exists(magnet, save_path, debug=False):
     parsed = parse_magnet_simple(magnet)
     if not parsed.get("ok"):
@@ -493,6 +547,9 @@ def check_magnet_exists(magnet, save_path, debug=False):
             compact2 = re.sub(r'\s+', ' ', keyword).strip()
             if compact2 and compact2 not in keywords:
                 keywords.append(compact2)
+        for it in _extra_keywords_from_dn(dn):
+            if it not in keywords:
+                keywords.append(it)
         norm_dn = _normalize_for_comparison(dn)
         if dbg is not None:
             dbg["dn"] = dn

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -389,8 +389,9 @@ def _normalize_for_comparison(name):
     name = re.split(r'\s*\+\s*', name)[0]
     name = re.sub(r'\]\s+\[', '][', name)
     name = name.lower()
+    name = name.translate(str.maketrans('０１２３４５６７８９', '0123456789'))
     name = name.replace('・', '').replace('♡', '').replace('❤', '').replace('♥', '')
-    name = name.replace('~', '').replace('～', '').replace('〜', '').replace('！', '').replace('：', '')
+    name = name.replace('~', '').replace('～', '').replace('〜', '').replace('！', '').replace('：', '').replace(':', '')
     name = re.sub(r'\(\s*mdf\s*\+\s*mds\s*\)', '', name)
     name = re.sub(r'\(\s*mdf\+mds\s*\)', '', name)
     name = re.sub(r'\b(disc|disk)\s*\d+\b', '', name)
@@ -401,6 +402,28 @@ def _normalize_for_comparison(name):
     name = re.sub(r'\bmini\s*adv\b', '', name)
     name = re.sub(r'[\s\-_.]+', ' ', name).strip()
     return name
+
+
+_DATE_PREFIX_RE = re.compile(r'^\[(\d{6})\]')
+_DATE_BRACKET_RE = re.compile(r'^\[\d{6}\]\s*')
+
+
+def _names_match(norm_dn, norm_fname):
+    if not norm_dn or not norm_fname:
+        return False
+    if norm_dn in norm_fname or norm_fname in norm_dn:
+        return True
+    m_dn = _DATE_PREFIX_RE.match(norm_dn)
+    m_fn = _DATE_PREFIX_RE.match(norm_fname)
+    if not m_dn or not m_fn:
+        return False
+    if m_dn.group(1) == m_fn.group(1):
+        return False
+    dn_no_date = _DATE_BRACKET_RE.sub('', norm_dn, count=1)
+    fn_no_date = _DATE_BRACKET_RE.sub('', norm_fname, count=1)
+    if dn_no_date and fn_no_date:
+        return dn_no_date in fn_no_date or fn_no_date in dn_no_date
+    return False
 
 
 def _search_keyword_from_dn(dn):
@@ -569,7 +592,7 @@ def check_magnet_exists(magnet, save_path, debug=False):
                 for f in files:
                     fname = f.get("n", "") if isinstance(f, dict) else ""
                     norm_fname = _normalize_for_comparison(fname)
-                    if norm_dn and norm_fname and (norm_dn in norm_fname or norm_fname in norm_dn):
+                    if _names_match(norm_dn, norm_fname):
                         matched_files.append({
                             "name": fname,
                             "size": f.get("s") if isinstance(f, dict) else None,
@@ -601,7 +624,7 @@ def check_magnet_exists(magnet, save_path, debug=False):
                         for f in files:
                             fname = f.get("n", "") if isinstance(f, dict) else ""
                             norm_fname = _normalize_for_comparison(fname)
-                            if norm_dn and norm_fname and (norm_dn in norm_fname or norm_fname in norm_dn):
+                            if _names_match(norm_dn, norm_fname):
                                 matched_files.append({
                                     "name": fname,
                                     "size": f.get("s") if isinstance(f, dict) else None,
@@ -635,7 +658,7 @@ def check_magnet_exists(magnet, save_path, debug=False):
                     for f in files:
                         fname = f.get("n", "") if isinstance(f, dict) else ""
                         norm_fname = _normalize_for_comparison(fname)
-                        if norm_dn and norm_fname and (norm_dn in norm_fname or norm_fname in norm_dn):
+                        if _names_match(norm_dn, norm_fname):
                             matched_files.append({
                                 "name": fname,
                                 "size": f.get("s") if isinstance(f, dict) else None,
@@ -662,7 +685,7 @@ def check_magnet_exists(magnet, save_path, debug=False):
                 for f in broad:
                     fname = f.get("n", "") if isinstance(f, dict) else ""
                     norm_fname = _normalize_for_comparison(fname)
-                    if norm_dn and norm_fname and (norm_dn in norm_fname or norm_fname in norm_dn):
+                    if _names_match(norm_dn, norm_fname):
                         matched_files.append({
                             "name": fname,
                             "size": f.get("s") if isinstance(f, dict) else None,

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -413,6 +413,10 @@ def _names_match(norm_dn, norm_fname):
         return False
     if norm_dn in norm_fname or norm_fname in norm_dn:
         return True
+    dn_compact = norm_dn.replace(" ", "")
+    fn_compact = norm_fname.replace(" ", "")
+    if dn_compact and fn_compact and (dn_compact in fn_compact or fn_compact in dn_compact):
+        return True
     m_dn = _DATE_PREFIX_RE.match(norm_dn)
     m_fn = _DATE_PREFIX_RE.match(norm_fname)
     if not m_dn or not m_fn:

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -430,10 +430,10 @@ def _search_keyword_from_dn(dn):
     return name.strip()[:30]
 
 
-def check_magnet_exists(magnet, save_path):
+def check_magnet_exists(magnet, save_path, debug=False):
     parsed = parse_magnet_simple(magnet)
     if not parsed.get("ok"):
-        return {
+        out = {
             "exists": False,
             "confidence": "none",
             "infohash_hex": parsed.get("infohash_hex"),
@@ -441,6 +441,9 @@ def check_magnet_exists(magnet, save_path):
             "in_offline_tasks": False,
             "message": "磁链解析失败: " + ", ".join(parsed.get("errors", [])),
         }
+        if debug:
+            out["debug"] = {"stage": "parse_magnet_simple", "parsed": parsed}
+        return out
 
     infohash_hex = parsed.get("infohash_hex")
     dn = parsed.get("dn", "")
@@ -448,6 +451,16 @@ def check_magnet_exists(magnet, save_path):
     matched_files = []
     in_offline = False
     confidence = "none"
+
+    dbg = None
+    if debug:
+        dbg = {
+            "parsed": parsed,
+            "has_cookie_file": bool(_read_cookie_string()),
+            "save_path_input": save_path,
+            "save_path_default": _get_default_save_path(),
+            "steps": [],
+        }
 
     ol = offline_list()
     if ol.get("success"):
@@ -460,6 +473,11 @@ def check_magnet_exists(magnet, save_path):
                 if magnet.lower() in task_url or (infohash_hex and infohash_hex in task_url):
                     in_offline = True
                     break
+        if dbg is not None:
+            dbg["steps"].append({"stage": "offline_list", "success": True, "tasks_len": len(tasks), "in_offline": in_offline})
+    else:
+        if dbg is not None:
+            dbg["steps"].append({"stage": "offline_list", "success": False, "message": ol.get("message")})
 
     if dn:
         actual_save_path = save_path or _get_default_save_path()
@@ -475,10 +493,20 @@ def check_magnet_exists(magnet, save_path):
             if compact2 and compact2 not in keywords:
                 keywords.append(compact2)
         norm_dn = _normalize_for_comparison(dn)
+        if dbg is not None:
+            dbg["dn"] = dn
+            dbg["norm_dn"] = norm_dn
+            dbg["actual_save_path"] = actual_save_path
+            dbg["cid"] = cid
+            dbg["keyword_primary"] = keyword
+            dbg["keywords"] = keywords
+
         if cid is not None:
             files = []
             for kw in keywords:
                 files = search_files(kw, cid)
+                if dbg is not None:
+                    dbg["steps"].append({"stage": "search_files", "mode": "keyword", "query": kw, "cid": cid, "result_len": len(files)})
                 for f in files:
                     fname = f.get("n", "") if isinstance(f, dict) else ""
                     norm_fname = _normalize_for_comparison(fname)
@@ -488,6 +516,18 @@ def check_magnet_exists(magnet, save_path):
                             "size": f.get("s") if isinstance(f, dict) else None,
                             "pick_code": f.get("pc") if isinstance(f, dict) else None,
                         })
+                if dbg is not None:
+                    dbg["steps"].append({
+                        "stage": "match_compare",
+                        "mode": "keyword",
+                        "query": kw,
+                        "matched_len": len(matched_files),
+                        "sample_files": [
+                            {"name": (it.get("n") or ""), "norm": _normalize_for_comparison(it.get("n") or "")}
+                            for it in (files[:5] if isinstance(files, list) else [])
+                            if isinstance(it, dict)
+                        ],
+                    })
                 if matched_files:
                     break
 
@@ -497,6 +537,8 @@ def check_magnet_exists(magnet, save_path):
                 if date_code:
                     for kw in (date_code, f"[{date_code}]"):
                         files = search_files(kw, cid or 0)
+                        if dbg is not None:
+                            dbg["steps"].append({"stage": "search_files", "mode": "date_code", "query": kw, "cid": cid or 0, "result_len": len(files)})
                         for f in files:
                             fname = f.get("n", "") if isinstance(f, dict) else ""
                             norm_fname = _normalize_for_comparison(fname)
@@ -506,6 +548,18 @@ def check_magnet_exists(magnet, save_path):
                                     "size": f.get("s") if isinstance(f, dict) else None,
                                     "pick_code": f.get("pc") if isinstance(f, dict) else None,
                                 })
+                        if dbg is not None:
+                            dbg["steps"].append({
+                                "stage": "match_compare",
+                                "mode": "date_code",
+                                "query": kw,
+                                "matched_len": len(matched_files),
+                                "sample_files": [
+                                    {"name": (it.get("n") or ""), "norm": _normalize_for_comparison(it.get("n") or "")}
+                                    for it in (files[:5] if isinstance(files, list) else [])
+                                    if isinstance(it, dict)
+                                ],
+                            })
                         if matched_files:
                             break
 
@@ -517,6 +571,8 @@ def check_magnet_exists(magnet, save_path):
                 name_no_bracket = re.sub(r'\[[^\]]+\]', '', name_no_bracket).strip()
                 if len(name_no_bracket) >= 3:
                     files = search_files(name_no_bracket[:20], cid or 0)
+                    if dbg is not None:
+                        dbg["steps"].append({"stage": "search_files", "mode": "plain_name", "query": name_no_bracket[:20], "cid": cid or 0, "result_len": len(files)})
                     for f in files:
                         fname = f.get("n", "") if isinstance(f, dict) else ""
                         norm_fname = _normalize_for_comparison(fname)
@@ -526,10 +582,24 @@ def check_magnet_exists(magnet, save_path):
                                 "size": f.get("s") if isinstance(f, dict) else None,
                                 "pick_code": f.get("pc") if isinstance(f, dict) else None,
                             })
+                    if dbg is not None:
+                        dbg["steps"].append({
+                            "stage": "match_compare",
+                            "mode": "plain_name",
+                            "query": name_no_bracket[:20],
+                            "matched_len": len(matched_files),
+                            "sample_files": [
+                                {"name": (it.get("n") or ""), "norm": _normalize_for_comparison(it.get("n") or "")}
+                                for it in (files[:5] if isinstance(files, list) else [])
+                                if isinstance(it, dict)
+                            ],
+                        })
 
         if not matched_files and not in_offline and infohash_hex:
             try:
                 broad = search_files(infohash_hex[:12], cid or 0)
+                if dbg is not None:
+                    dbg["steps"].append({"stage": "search_files", "mode": "infohash_prefix", "query": infohash_hex[:12], "cid": cid or 0, "result_len": len(broad)})
                 for f in broad:
                     fname = f.get("n", "") if isinstance(f, dict) else ""
                     norm_fname = _normalize_for_comparison(fname)
@@ -556,7 +626,7 @@ def check_magnet_exists(magnet, save_path):
         if broad:
             confidence = "low"
 
-    return {
+    out = {
         "exists": bool(matched_files) or in_offline,
         "confidence": confidence,
         "infohash_hex": infohash_hex,
@@ -564,3 +634,9 @@ def check_magnet_exists(magnet, save_path):
         "in_offline_tasks": in_offline,
         "dn": dn,
     }
+    if dbg is not None:
+        dbg["result"] = {"matched_len": len(matched_files), "in_offline": in_offline, "confidence": confidence}
+        out["debug"] = dbg
+    if dbg is not None and not dbg.get("has_cookie_file"):
+        out["message"] = "cookie文件不存在或为空，可能未登录导致搜索结果为空"
+    return out

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -390,7 +390,7 @@ def _normalize_for_comparison(name):
     name = re.sub(r'\]\s+\[', '][', name)
     name = name.lower()
     name = name.translate(str.maketrans('０１２３４５６７８９', '0123456789'))
-    for ch in '・♡❤♥~～〜！!？?：:':
+    for ch in '・♡❤♥~～〜！!？?：:『』「」－–—−―ｰ':
         name = name.replace(ch, '')
     for pattern in (
         r'\(\s*mdf\s*\+\s*mds\s*\)',
@@ -400,6 +400,7 @@ def _normalize_for_comparison(name):
         r'\[\s*\d[\d.,]*(?:\.\d+)?\s*(?:k|m|g|t)i?b\s*\]',
         r'\b(?:crack|patch|update)\b',
         r'(?:パッケージ版|ダウンロード版|dl\s*版|通常版)',
+        r'\[\s*\]',
         r'\bmini\s*adv\b',
     ):
         name = re.sub(pattern, '', name)

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -587,6 +587,7 @@ def check_magnet_exists(magnet, save_path, debug=False):
     matched_files = []
     in_offline = False
     confidence = "none"
+    matched_in_other_dir = False
 
     dbg = None
     if debug:
@@ -734,6 +735,38 @@ def check_magnet_exists(magnet, save_path, debug=False):
                             ],
                         })
 
+        matched_in_other_dir = False
+        if not matched_files and cid:
+            for kw in keywords[:8]:
+                files2 = search_files(kw, 0)
+                if dbg is not None:
+                    dbg["steps"].append({"stage": "search_files", "mode": "global_keyword", "query": kw, "cid": 0, "result_len": len(files2)})
+                for f in files2:
+                    fname = f.get("n", "") if isinstance(f, dict) else ""
+                    norm_fname = _normalize_for_comparison(fname)
+                    if _names_match(norm_dn, norm_fname):
+                        matched_in_other_dir = True
+                        matched_files.append({
+                            "name": fname,
+                            "size": f.get("s") if isinstance(f, dict) else None,
+                            "pick_code": f.get("pc") if isinstance(f, dict) else None,
+                            "cid": f.get("cid") if isinstance(f, dict) else None,
+                        })
+                if dbg is not None:
+                    dbg["steps"].append({
+                        "stage": "match_compare",
+                        "mode": "global_keyword",
+                        "query": kw,
+                        "matched_len": len(matched_files),
+                        "sample_files": [
+                            {"name": (it.get("n") or ""), "norm": _normalize_for_comparison(it.get("n") or "")}
+                            for it in (files2[:5] if isinstance(files2, list) else [])
+                            if isinstance(it, dict)
+                        ],
+                    })
+                if matched_files:
+                    break
+
         if not matched_files and not in_offline and infohash_hex:
             try:
                 broad = search_files(infohash_hex[:12], cid or 0)
@@ -773,6 +806,8 @@ def check_magnet_exists(magnet, save_path, debug=False):
         "in_offline_tasks": in_offline,
         "dn": dn,
     }
+    if matched_in_other_dir:
+        out["matched_in_other_dir"] = True
     if dbg is not None:
         dbg["result"] = {"matched_len": len(matched_files), "in_offline": in_offline, "confidence": confidence}
         out["debug"] = dbg

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -395,6 +395,7 @@ def _normalize_for_comparison(name):
     name = re.sub(r'\[(\d{7,})\]', '', name)
     name = re.sub(r'\[\s*\d+(?:\.\d+)?\s*(?:kb|mb|gb|tb)\s*\]', '', name)
     name = re.sub(r'\b(?:crack|patch|update)\b', '', name)
+    name = re.sub(r'(?:パッケージ版|ダウンロード版|dl\s*版|通常版)', '', name)
     name = re.sub(r'\bmini\s*adv\b', '', name)
     name = re.sub(r'[\s\-_.]+', ' ', name).strip()
     return name
@@ -464,33 +465,49 @@ def check_magnet_exists(magnet, save_path):
         actual_save_path = save_path or _get_default_save_path()
         cid = _resolve_path_to_cid(actual_save_path) if actual_save_path else 0
         keyword = _search_keyword_from_dn(dn)
+        keywords = []
+        if keyword:
+            keywords.append(keyword)
+            compact = keyword.replace("] [", "][")
+            if compact != keyword:
+                keywords.append(compact)
+            compact2 = re.sub(r'\s+', ' ', keyword).strip()
+            if compact2 and compact2 not in keywords:
+                keywords.append(compact2)
         norm_dn = _normalize_for_comparison(dn)
         if cid is not None:
-            files = search_files(keyword, cid)
-            for f in files:
-                fname = f.get("n", "") if isinstance(f, dict) else ""
-                norm_fname = _normalize_for_comparison(fname)
-                if norm_dn and norm_fname and (norm_dn in norm_fname or norm_fname in norm_dn):
-                    matched_files.append({
-                        "name": fname,
-                        "size": f.get("s") if isinstance(f, dict) else None,
-                        "pick_code": f.get("pc") if isinstance(f, dict) else None,
-                    })
+            files = []
+            for kw in keywords:
+                files = search_files(kw, cid)
+                for f in files:
+                    fname = f.get("n", "") if isinstance(f, dict) else ""
+                    norm_fname = _normalize_for_comparison(fname)
+                    if norm_dn and norm_fname and (norm_dn in norm_fname or norm_fname in norm_dn):
+                        matched_files.append({
+                            "name": fname,
+                            "size": f.get("s") if isinstance(f, dict) else None,
+                            "pick_code": f.get("pc") if isinstance(f, dict) else None,
+                        })
+                if matched_files:
+                    break
 
             if not files and not matched_files:
                 brackets = re.findall(r'\[(\d{6})\]', dn)
                 date_code = brackets[0] if brackets else ""
                 if date_code:
-                    files = search_files(date_code, cid or 0)
-                    for f in files:
-                        fname = f.get("n", "") if isinstance(f, dict) else ""
-                        norm_fname = _normalize_for_comparison(fname)
-                        if norm_dn and norm_fname and (norm_dn in norm_fname or norm_fname in norm_dn):
-                            matched_files.append({
-                                "name": fname,
-                                "size": f.get("s") if isinstance(f, dict) else None,
-                                "pick_code": f.get("pc") if isinstance(f, dict) else None,
-                            })
+                    for kw in (date_code, f"[{date_code}]"):
+                        files = search_files(kw, cid or 0)
+                        for f in files:
+                            fname = f.get("n", "") if isinstance(f, dict) else ""
+                            norm_fname = _normalize_for_comparison(fname)
+                            if norm_dn and norm_fname and (norm_dn in norm_fname or norm_fname in norm_dn):
+                                matched_files.append({
+                                    "name": fname,
+                                    "size": f.get("s") if isinstance(f, dict) else None,
+                                    "pick_code": f.get("pc") if isinstance(f, dict) else None,
+                                })
+                        if matched_files:
+                            break
 
             if not files and not matched_files:
                 name_no_bracket = re.split(r'\s*\+\s*', dn)[0]
@@ -531,7 +548,11 @@ def check_magnet_exists(magnet, save_path):
         confidence = "high"
     elif dn and cid:
         keyword = _search_keyword_from_dn(dn)
-        broad = search_files(keyword[:max(8, len(keyword)//3)], cid)
+        broad_kw = keyword[:max(8, len(keyword)//3)] if keyword else ""
+        broad_kw2 = broad_kw.replace("] [", "][") if broad_kw else ""
+        broad = search_files(broad_kw, cid) if broad_kw else []
+        if not broad and broad_kw2 and broad_kw2 != broad_kw:
+            broad = search_files(broad_kw2, cid)
         if broad:
             confidence = "low"
 

--- a/tool/p115_client.py
+++ b/tool/p115_client.py
@@ -423,6 +423,23 @@ def _leading_date_codes(s):
     return codes
 
 
+def _strip_leading_dates_and_tags(s):
+    s = (s or "").strip()
+    while True:
+        m = _DATE_PREFIX_RE.match(s)
+        if not m:
+            break
+        s = s[m.end():].lstrip()
+    while True:
+        if not s.startswith('['):
+            break
+        end = s.find(']')
+        if end <= 0:
+            break
+        s = s[end + 1:].lstrip()
+    return s.strip()
+
+
 def _names_match(norm_dn, norm_fname):
     if not norm_dn or not norm_fname:
         return False
@@ -440,6 +457,15 @@ def _names_match(norm_dn, norm_fname):
             common = c
             break
     if not common:
+        dn_tail = _strip_leading_dates_and_tags(norm_dn)
+        fn_tail = _strip_leading_dates_and_tags(norm_fname)
+        if dn_tail and fn_tail and (len(dn_tail) >= 8 or len(fn_tail) >= 8):
+            if dn_tail in fn_tail or fn_tail in dn_tail:
+                return True
+            dn2 = dn_tail.replace(" ", "")
+            fn2 = fn_tail.replace(" ", "")
+            if dn2 and fn2 and (dn2 in fn2 or fn2 in dn2):
+                return True
         return False
 
     dn_no_date = re.sub(r'^\[' + re.escape(common) + r'\]\s*', '', norm_dn, count=1)


### PR DESCRIPTION
## 主要内容
- 数据页：当月“全部已下载”提示；批量校验按钮逻辑修复
- 年历页：3年视图 + 整年级别的“链接/校对/下载(推送115)”入口
- 115：校验匹配增强与 debug 输出；新增独立校对调试页并可从模态框跳转
- 闲时自动化：idle_run 仅处理上月及之前，并支持“每周只跑一次”去重

## 数据库变更
- getchu_games 新增字段：submitted_115 / submitted_pick_code（启动时自动兼容迁移）

## 说明
- 本 PR 变更较大（涉及 web + tool + 115 匹配），建议按页面与 CLI 分别回归。
